### PR TITLE
Document yarn release, add .yarnrc & .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/**/*.js
+storybook-static/**/*.js

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ npm install --save @storybook/design-system
 ## Usage
 
 ```jsx
-import React, { Component } from "react";
+import React, { Component } from 'react';
 
-import MyComponent from "@storybook/design-system";
+import MyComponent from '@storybook/design-system';
 
 class Example extends Component {
   render() {
@@ -23,6 +23,21 @@ class Example extends Component {
   }
 }
 ```
+
+## Development Scripts
+
+#### `yarn release`
+
+> Bump the version
+
+> Push a release to GitHub and npm
+
+> Push a changelog to GitHub
+
+_Notes:_
+
+- Requires authentication with [`npm adduser`](https://docs.npmjs.com/cli/adduser.html)
+- [`auto`](https://github.com/intuit/auto) is used to generate a changelog and push it to GitHub. In order for this to work correctly, **an environment variable called `GH_TOKEN` is needed** that references a [GitHub personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) with the appropriate permissions to update the repo.
 
 ## License
 


### PR DESCRIPTION
The `.yarnrc` file lets us run `yarn publish` without having yarn assume that we want to push to the yarn registry.

Let me know if the docs I added make sense or could be formatted any better.

I made a bit of a mess doing this publishing & unpublishing packages/changelogs, but I think I have it cleaned up now. There might be a slight issue once the next version is released as NPM won't allow `0.0.15` since I have already published & unpublished it (it had nothing in it). The `package.json` currently says `0.0.14` so I think `auto` is going to think that the next version is `0.0.15` and try to push to NPM, but that will fail. @shilman any thoughts on how to fix this?