### PR TITLE
Export Highlight for consumption

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export * from './Avatar';
 export * from './AvatarList';
 export * from './Badge';
 export * from './Button';
+export { default as Highlight } from './Highlight';
 export * from './Icon';
 export * from './Link';
 export * from './Subheading';


### PR DESCRIPTION
Missed this last time -- I thought all the components were exported automatically.