### PR TITLE
Fix LinkWrapper props to avoid collisions w React, Gatsby, etc links

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -34,7 +34,7 @@ const HighlightBlock = styled.div`
   }
 `;
 
-class Highlight extends React.Component {
+export class Highlight extends React.Component {
   componentDidMount() {
     this.highlightCode();
   }
@@ -62,5 +62,3 @@ class Highlight extends React.Component {
 Highlight.propTypes = {
   children: PropTypes.node.isRequired,
 };
-
-export default Highlight;

--- a/src/components/Highlight.stories.js
+++ b/src/components/Highlight.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Highlight from './Highlight';
+import { Highlight } from './Highlight';
 
 const bash = `
 <pre class="language-bash"><code class="language-bash"><span class="token comment"># Highlight bash:</span>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -147,11 +147,8 @@ export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children,
 
   if (LinkWrapper) {
     const StyledLinkWrapper = LinkA.withComponent(LinkWrapper);
-    const linkWrapperProps = { ...rest };
-    delete linkWrapperProps.inverse;
-    delete linkWrapperProps.nochrome;
-    delete linkWrapperProps.secondary;
-    delete linkWrapperProps.tertiary;
+    const { inverse, nochrome, secondary, tertiary, ...linkWrapperProps } = rest;
+
     return <StyledLinkWrapper {...linkWrapperProps}>{content}</StyledLinkWrapper>;
   }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -135,7 +135,7 @@ const LinkButton = styled.button`
   ${linkStyles};
 `;
 
-export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children, ...props }) {
+export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children, ...rest }) {
   const content = (
     <Fragment>
       <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
@@ -147,12 +147,19 @@ export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children,
 
   if (LinkWrapper) {
     const StyledLinkWrapper = LinkA.withComponent(LinkWrapper);
-    return <StyledLinkWrapper {...props}>{content}</StyledLinkWrapper>;
+    const linkWrapperProps = { ...rest };
+    delete linkWrapperProps.inverse;
+    delete linkWrapperProps.nochrome;
+    delete linkWrapperProps.secondary;
+    delete linkWrapperProps.tertiary;
+    return <StyledLinkWrapper {...linkWrapperProps}>{content}</StyledLinkWrapper>;
   }
+
   if (isButton) {
-    return <LinkButton {...props}>{content}</LinkButton>;
+    return <LinkButton {...rest}>{content}</LinkButton>;
   }
-  return <LinkA {...props}>{content}</LinkA>;
+
+  return <LinkA {...rest}>{content}</LinkA>;
 }
 
 Link.propTypes = {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,7 +9,7 @@ export * from './Avatar';
 export * from './AvatarList';
 export * from './Badge';
 export * from './Button';
-export { default as Highlight } from './Highlight';
+export * from './Highlight';
 export * from './Icon';
 export * from './Link';
 export * from './Subheading';


### PR DESCRIPTION
I tried to fix this in an earlier PR, but I didn't get it right. I think I have it now -- A lot of the `Link` components that you use w/ other libs like  Gatsby & React Router complain when you pass them props that are not standard. I kept seeing errors for this in the console:

![Screen Shot 2019-06-06 at 5 38 24 PM](https://user-images.githubusercontent.com/3035355/59072919-e83d4900-8881-11e9-9588-92029ce087bb.png)

I decided to just manually delete the props from the prop object that is passed down to the `LinkWrapper` -- that seemed to do the trick.