### PR TITLE
fix: Avatar accessibility

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -103,17 +103,24 @@ const Initial = styled.div`
  */
 export function Avatar({ loading, username, src, size, ...props }) {
   let avatarFigure = <Icon icon="useralt" />;
+  const a11yProps = {};
 
-  if (!loading) {
-    if (!src) {
-      avatarFigure = <Initial size={size}>{username.substring(0, 1)}</Initial>;
-    } else {
-      avatarFigure = <img src={src} alt={username} />;
-    }
+  if (loading) {
+    a11yProps['aria-busy'] = true;
+    a11yProps['aria-label'] = 'Loading avatar ...';
+  } else if (src) {
+    avatarFigure = <img src={src} alt={username} />;
+  } else {
+    a11yProps['aria-label'] = username;
+    avatarFigure = (
+      <Initial size={size} aria-hidden="true">
+        {username.substring(0, 1)}
+      </Initial>
+    );
   }
 
   return (
-    <Image size={size} loading={loading} src={src} {...props}>
+    <Image size={size} loading={loading} src={src} {...a11yProps} {...props}>
       {avatarFigure}
     </Image>
   );


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Avatar component is not accessible

![non-a11y](https://user-images.githubusercontent.com/10761073/59468825-5ca05b00-8e33-11e9-9ee4-561c03f78e91.gif)

(SR = Screen Reader)

1. The loading avatar is just skipped by SR (yeah I added a "lol" text on the left to show that the focus switch between the elements between the loading avatar, it's kind of my default text when I don't know what to write :D )
A loader should have aria-busy attribute and a text alternative if it doesn't contains explicit text.

2. The initial avatar alt attribute is not taken into account by SR, it reads only the initial letter

**What is the chosen solution to this problem?**

1. Set the aria-busy attribute and a `Loading avatar ...` aria-label

2. Hide the initial with aria-hidden, and set the username in an aria-label instead of alt attribute

![a11y](https://user-images.githubusercontent.com/10761073/59469465-2a8ff880-8e35-11e9-996d-ea7f036ea59c.gif)
