### PR TITLE
fix: avatar list accessibility

### DIFF
--- a/src/components/AvatarList.js
+++ b/src/components/AvatarList.js
@@ -7,12 +7,12 @@ import WithTooltip from './tooltip/WithTooltip';
 import { TooltipNote } from './tooltip/TooltipNote';
 import { color, typography } from './shared/styles';
 
-const User = styled(Avatar)`
+const UserAvatar = styled(Avatar)`
   box-shadow: ${color.lightest} 0 0 0 2px;
   display: block;
 `;
 
-const UserWrapper = styled(WithTooltip)``;
+const UserTooltipWrapper = styled(WithTooltip)``;
 
 const UserEllipses = styled.div`
   font-size: ${typography.size.s1}px;
@@ -21,15 +21,20 @@ const UserEllipses = styled.div`
   white-space: nowrap;
 `;
 
-const Users = styled.div`
+const User = styled.li``;
+
+const Users = styled.ul`
   display: inline-flex;
   flex-wrap: nowrap;
   flex-direction: row;
   align-items: center;
   justify-content: flex-end;
   vertical-align: top;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 
-  ${UserWrapper} {
+  ${User} {
     position: relative;
 
     &:not(:first-child) {
@@ -51,19 +56,22 @@ const Users = styled.div`
 export function AvatarList({ loading, users, userCount, size, ...props }) {
   const count = userCount || users.length;
   return (
-    <Users {...props}>
+    <Users aria-label="users" {...props}>
       {users.slice(0, 3).map(({ id, name, avatarUrl }) => (
-        <UserWrapper
-          key={id}
-          hasChrome={false}
-          placement="bottom"
-          mode="hover"
-          tooltip={<TooltipNote note={name} />}
-        >
-          <User size={size} username={name} src={avatarUrl} loading={loading} />
-        </UserWrapper>
+        <User key={id}>
+          <UserTooltipWrapper
+            hasChrome={false}
+            placement="bottom"
+            mode="hover"
+            tooltip={<TooltipNote note={name} />}
+          >
+            <UserAvatar size={size} username={name} src={avatarUrl} loading={loading} />
+          </UserTooltipWrapper>
+        </User>
       ))}
-      {count > 3 && <UserEllipses> &#43; {count - 3} </UserEllipses>}
+      {count > 3 && (
+        <UserEllipses aria-label={`${count - 3} more user(s)`}> &#43; {count - 3} </UserEllipses>
+      )}
     </Users>
   );
 }

--- a/src/components/AvatarList.js
+++ b/src/components/AvatarList.js
@@ -21,7 +21,9 @@ const UserEllipses = styled.div`
   white-space: nowrap;
 `;
 
-const User = styled.li``;
+const User = styled.li`
+  display: inline-flex;
+`;
 
 const Users = styled.ul`
   display: inline-flex;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Avatar list component is not accessible

![non-a11y](https://user-images.githubusercontent.com/10761073/59536053-e5ca9700-8ef2-11e9-8611-f5ad1857367f.gif)

(SR = Screen Reader)

1. The semantic is not right. It's a list of elements but it's a succession of divs. SR doesn't announce that as a list. In fact it should announce that as a `list of users`.

2. On big lists with ellipsis, the ellipsis is a text (example: `+ 97`). But it's not understandable, out of context. And with the previous issue about semantic, the context (which is a list of users) is not here. 

**What is the chosen solution to this problem?**

1. Use ul/li to create the list. Add an aria-label `users`, so SR
* will announce a `list "users"`,
* tell the index of the focused element,
* the number of elements in the list

2. Add an aria-label with a more complete string (example: `+97 more user(s)`)

![a11y](https://user-images.githubusercontent.com/10761073/59536507-2ecf1b00-8ef4-11e9-8dca-f1336e8d2c27.gif)

