### PR TITLE
fix: AvatarList ellipsis in an li

### DIFF
--- a/src/components/AvatarList.js
+++ b/src/components/AvatarList.js
@@ -14,7 +14,8 @@ const UserAvatar = styled(Avatar)`
 
 const UserTooltipWrapper = styled(WithTooltip)``;
 
-const UserEllipses = styled.div`
+const UserEllipses = styled.li`
+  display: inline-flex;
   font-size: ${typography.size.s1}px;
   color: ${color.mediumdark};
   margin-left: 6px;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
#14 fixed the AvatarList semantic with ul/li. But the ellipsis is still in a div.

**What is the chosen solution to this problem?**
Use li for the ellipsis instead.