### PR TITLE
chore: button icon only demo text alternative

### DIFF
--- a/src/components/Button.stories.js
+++ b/src/components/Button.stories.js
@@ -49,7 +49,7 @@ storiesOf('Design System|Button', module)
         Disabled
       </Button>
       <Button appearance="outline" size="small" containsIcon>
-        <Icon icon="link" />
+        <Icon icon="link" aria-label="Link" />
       </Button>
       <Button appearance="outline" size="small">
         <Icon icon="link" />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Button story has an icon-only button, without text alternative.

**What is the chosen solution to this problem?**
Fix the story, adding an aria-label to the icon-only button.