### PR TITLE
Add support for closeOnClick to WithTooltip

### DIFF
--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import TooltipTrigger from 'react-popper-tooltip';
-import { withState } from 'recompose';
 
 import { Tooltip } from './Tooltip';
 
@@ -25,17 +24,27 @@ function WithTooltip({
   hasChrome,
   tooltip,
   children,
-  tooltipShown,
+  startOpen,
   onVisibilityChange,
   ...props
 }) {
   const Container = svg ? TargetSvgContainer : TargetContainer;
+  const [isTooltipShown, setTooltipShown] = useState(startOpen);
+  const toggleTooltipShown = () => setTooltipShown(!isTooltipShown);
+  const closeTooltipOnClick = () => {
+    if (!closeOnClick) {
+      return;
+    }
+
+    setTooltipShown(false);
+  };
+
   return (
     <TooltipTrigger
       placement={placement}
       trigger={trigger}
-      tooltipShown={tooltipShown}
-      onVisibilityChange={onVisibilityChange}
+      tooltipShown={isTooltipShown}
+      onVisibilityChange={toggleTooltipShown}
       modifiers={modifiers}
       tooltip={({
         getTooltipProps,
@@ -50,6 +59,7 @@ function WithTooltip({
           tooltipRef={tooltipRef}
           arrowRef={arrowRef}
           arrowProps={getArrowProps()}
+          onClick={closeTooltipOnClick}
           {...getTooltipProps()}
         >
           {typeof tooltip === 'function'
@@ -59,7 +69,7 @@ function WithTooltip({
       )}
     >
       {({ getTriggerProps, triggerRef }) => (
-        <Container ref={triggerRef} {...getTriggerProps()} {...props}>
+        <Container ref={triggerRef} {...getTriggerProps()} {...props} onClick={toggleTooltipShown}>
           {children}
         </Container>
       )}
@@ -76,7 +86,7 @@ WithTooltip.propTypes = {
   hasChrome: PropTypes.bool,
   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   children: PropTypes.node.isRequired,
-  tooltipShown: PropTypes.bool,
+  startOpen: PropTypes.bool,
   onVisibilityChange: PropTypes.func.isRequired,
 };
 
@@ -87,9 +97,7 @@ WithTooltip.defaultProps = {
   placement: 'top',
   modifiers: {},
   hasChrome: true,
-  tooltipShown: false,
+  startOpen: false,
 };
 
-export default withState('tooltipShown', 'onVisibilityChange', ({ startOpen }) => startOpen)(
-  WithTooltip
-);
+export default WithTooltip;

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -25,7 +25,6 @@ function WithTooltip({
   tooltip,
   children,
   startOpen,
-  onVisibilityChange,
   ...props
 }) {
   const Container = svg ? TargetSvgContainer : TargetContainer;
@@ -63,7 +62,7 @@ function WithTooltip({
           {...getTooltipProps()}
         >
           {typeof tooltip === 'function'
-            ? tooltip({ onHide: () => onVisibilityChange(false) })
+            ? tooltip({ onHide: () => setTooltipShown(false) })
             : tooltip}
         </Tooltip>
       )}
@@ -87,7 +86,6 @@ WithTooltip.propTypes = {
   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   children: PropTypes.node.isRequired,
   startOpen: PropTypes.bool,
-  onVisibilityChange: PropTypes.func.isRequired,
 };
 
 WithTooltip.defaultProps = {

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -15,6 +15,20 @@ const TargetSvgContainer = styled.g`
   cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
 `;
 
+const isDescendantOfAction = element => {
+  const { parentElement } = element;
+
+  if (parentElement.tagName === 'BODY') {
+    return false;
+  }
+
+  if (parentElement.tagName === 'A' || parentElement.tagName === 'BUTTON') {
+    return true;
+  }
+
+  return isDescendantOfAction(parentElement);
+};
+
 function WithTooltip({
   svg,
   trigger,
@@ -30,8 +44,8 @@ function WithTooltip({
   const Container = svg ? TargetSvgContainer : TargetContainer;
   const [isTooltipShown, setTooltipShown] = useState(startOpen);
   const toggleTooltipShown = () => setTooltipShown(!isTooltipShown);
-  const closeTooltipOnClick = () => {
-    if (!closeOnClick) {
+  const closeTooltipOnClick = event => {
+    if (!closeOnClick || !isDescendantOfAction(event.target)) {
       return;
     }
 


### PR DESCRIPTION
Support for `closeOnClick` in `WithTooltp`. Sadly, you have to manage your own state for the tooltip if you want to support this feature. It is not too much additional effort, though, but you have to be careful to put the event handlers in the right places (1 for onVisibilityChange, 1 for the tooltip trigger, and 1 for the tooltip itself).

Gif below showing:
1. Outside click detection still working
2. closeOnClick working when the appropriate prop is passed
3. no closeOnClick behavior when the prop is not passed in

![closeOnClick](https://user-images.githubusercontent.com/3035355/59621303-4113a980-90ec-11e9-86bc-7fb13940ad57.gif)
