### PR TITLE
fix: invalid input with aria-invalid attribute

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -281,7 +281,13 @@ export function Input({
         focused={focused}
       >
         {icon && <Icon icon={icon} aria-hidden />}
-        <InputText id={id} value={value} aria-describedby={errorId} {...props} />
+        <InputText
+          id={id}
+          value={value}
+          aria-describedby={errorId}
+          aria-invalid={!!error}
+          {...props}
+        />
         <Error id={errorId}>{error}</Error>
       </InputWrapper>
     </InputContainer>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Input in error should have the `aria-invalid` attribute, so assistive technologies announce it as invalid user entry.

I forgot that in PR #18, sorry for that

**What is the chosen solution to this problem?**
Add the `aria-invalid` attribute on the input when we have an associated error.