### PR TITLE
fix: Textarea accessibility

### DIFF
--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -23,9 +23,6 @@ const Label = styled.label`
 const ErrorMessage = styled.span`
   color: ${color.negative};
   font-weight: ${typography.weight.regular};
-  &:not(:only-child) {
-    margin-left: 0.5em;
-  }
 `;
 
 const LabelWrapper = styled.div`
@@ -40,6 +37,14 @@ const LabelWrapper = styled.div`
     css`
       height: 0;
       margin: 0;
+    `}
+
+  ${props =>
+    !props.hideLabel &&
+    css`
+      ${ErrorMessage} {
+        margin-left: 0.5em;
+      }
     `}
 `;
 

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -3,7 +3,22 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { color, typography } from './shared/styles';
 
-const Label = styled.span``;
+const Label = styled.label`
+  ${props =>
+    props.hideLabel &&
+    css`
+      border: 0px !important;
+      clip: rect(0 0 0 0) !important;
+      -webkit-clip-path: inset(100%) !important;
+      clip-path: inset(100%) !important;
+      height: 1px !important;
+      overflow: hidden !important;
+      padding: 0px !important;
+      position: absolute !important;
+      white-space: nowrap !important;
+      width: 1px !important;
+    `}
+`;
 
 const ErrorMessage = styled.span`
   color: ${color.negative};
@@ -18,6 +33,14 @@ const LabelWrapper = styled.div`
   font-weight: ${props => props.appearance !== 'code' && typography.weight.extrabold};
   font-family: ${props => props.appearance === 'code' && typography.type.code};
   font-size: ${props => (props.appearance === 'code' ? typography.size.s1 : typography.size.s2)}px;
+
+  ${props =>
+    props.hideLabel &&
+    !props.error &&
+    css`
+      height: 0;
+      margin: 0;
+    `}
 `;
 
 const Subtext = styled.div``;
@@ -134,8 +157,10 @@ const TextareaContainer = styled.div`
 `;
 
 export function Textarea({
+  id,
   value,
   label,
+  hideLabel,
   error,
   subtext,
   subtextSentiment,
@@ -144,16 +169,25 @@ export function Textarea({
   className,
   ...other
 }) {
+  const errorId = `${id}-error`;
+
   return (
     <TextareaContainer orientation={orientation} className={className}>
-      {(label || error) && (
-        <LabelWrapper appearance={appearance}>
-          {label && <Label>{label}</Label>}
-          {error && <ErrorMessage>{error}</ErrorMessage>}
-        </LabelWrapper>
-      )}
+      <LabelWrapper appearance={appearance} hideLabel={hideLabel} error={error}>
+        <Label htmlFor={id} hideLabel={hideLabel}>
+          {label}
+        </Label>
+        <ErrorMessage id={errorId}>{error}</ErrorMessage>
+      </LabelWrapper>
       <TextareaWrapper error={error} appearance={appearance}>
-        <TextareaText value={value} rows="7" {...other} />
+        <TextareaText
+          id={id}
+          value={value}
+          rows="7"
+          aria-invalid={!!error}
+          aria-describedby={errorId}
+          {...other}
+        />
         {subtext && <Subtext sentiment={subtextSentiment}>{subtext}</Subtext>}
       </TextareaWrapper>
     </TextareaContainer>
@@ -161,9 +195,11 @@ export function Textarea({
 }
 
 Textarea.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   appearance: PropTypes.oneOf(['default', 'secondary', 'tertiary', 'code']),
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  hideLabel: PropTypes.bool,
   orientation: PropTypes.oneOf(['vertical', 'horizontal']),
   error: PropTypes.string,
   subtext: PropTypes.string,
@@ -173,7 +209,7 @@ Textarea.propTypes = {
 
 Textarea.defaultProps = {
   appearance: 'default',
-  label: null,
+  hideLabel: false,
   orientation: 'vertical',
   error: null,
   subtext: null,

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -177,7 +177,9 @@ export function Textarea({
         <Label htmlFor={id} hideLabel={hideLabel}>
           {label}
         </Label>
-        <ErrorMessage id={errorId}>{error}</ErrorMessage>
+        <ErrorMessage id={errorId} aria-hidden>
+          {error}
+        </ErrorMessage>
       </LabelWrapper>
       <TextareaWrapper error={error} appearance={appearance}>
         <TextareaText

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -170,6 +170,9 @@ export function Textarea({
   ...other
 }) {
   const errorId = `${id}-error`;
+  const subtextId = `${id}-subtext`;
+
+  const ariaDescribedBy = `${error ? errorId : ''} ${subtext ? subtextId : ''}`;
 
   return (
     <TextareaContainer orientation={orientation} className={className}>
@@ -177,9 +180,11 @@ export function Textarea({
         <Label htmlFor={id} hideLabel={hideLabel}>
           {label}
         </Label>
-        <ErrorMessage id={errorId} aria-hidden>
-          {error}
-        </ErrorMessage>
+        {error && (
+          <ErrorMessage id={errorId} aria-hidden>
+            {error}
+          </ErrorMessage>
+        )}
       </LabelWrapper>
       <TextareaWrapper error={error} appearance={appearance}>
         <TextareaText
@@ -187,10 +192,14 @@ export function Textarea({
           value={value}
           rows="7"
           aria-invalid={!!error}
-          aria-describedby={errorId}
+          aria-describedby={ariaDescribedBy}
           {...other}
         />
-        {subtext && <Subtext sentiment={subtextSentiment}>{subtext}</Subtext>}
+        {subtext && (
+          <Subtext id={subtextId} sentiment={subtextSentiment}>
+            {subtext}
+          </Subtext>
+        )}
       </TextareaWrapper>
     </TextareaContainer>
   );

--- a/src/components/Textarea.stories.js
+++ b/src/components/Textarea.stories.js
@@ -83,6 +83,14 @@ storiesOf('Design System|forms/Textarea', module)
         error="There's a snake in my boots"
         onChange={onChange}
       />
+      <Textarea
+        id="Subtext"
+        value="Subtext"
+        label="Textarea with subtext"
+        hideLabel
+        subtext="140 chars left"
+        onChange={onChange}
+      />
     </form>
   ))
   .add('secondary', () => (
@@ -131,6 +139,15 @@ storiesOf('Design System|forms/Textarea', module)
         appearance="secondary"
         onChange={onChange}
       />
+      <Textarea
+        id="Subtext"
+        value="Subtext"
+        label="Textarea with subtext"
+        hideLabel
+        subtext="140 chars left"
+        appearance="secondary"
+        onChange={onChange}
+      />
     </form>
   ))
   .add('tertiary', () => (
@@ -176,6 +193,15 @@ storiesOf('Design System|forms/Textarea', module)
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"
+        appearance="tertiary"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Subtext"
+        value="Subtext"
+        label="Textarea with subtext"
+        hideLabel
+        subtext="140 chars left"
         appearance="tertiary"
         onChange={onChange}
       />
@@ -234,6 +260,15 @@ storiesOf('Design System|forms/Textarea', module)
         error="There's a snake in my boots"
         appearance="code"
         orientation="horizontal"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Subtext"
+        value="Subtext"
+        label="Textarea with subtext"
+        hideLabel
+        subtext="140 chars left"
+        appearance="code"
         onChange={onChange}
       />
     </form>

--- a/src/components/Textarea.stories.js
+++ b/src/components/Textarea.stories.js
@@ -9,20 +9,75 @@ storiesOf('Design System|forms/Textarea', module)
   .addParameters({ component: Textarea })
   .add('all Textareas', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
-      <Textarea value="Default" onChange={onChange} />
-      <Textarea value="Secondary" appearance="secondary" onChange={onChange} />
-      <Textarea value="Tertiary" appearance="tertiary" onChange={onChange} />
-      <Textarea value="Code" appearance="code" onChange={onChange} />
+      <Textarea
+        id="Default"
+        label="Default textarea"
+        hideLabel
+        value="Default"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Secondary"
+        label="Secondary textarea"
+        hideLabel
+        value="Secondary"
+        appearance="secondary"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Tertiary"
+        label="Tertiary textarea"
+        hideLabel
+        value="Tertiary"
+        appearance="tertiary"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Code"
+        label="Code textarea"
+        hideLabel
+        value="Code"
+        appearance="code"
+        onChange={onChange}
+      />
     </form>
   ))
   .add('default', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
-      <Textarea value="placeholder" placeholder="Placeholder" onChange={onChange} />
-      <Textarea value="With value" onChange={onChange} />
-      <Textarea value="Disabled" disabled onChange={onChange} />
-      <Textarea label="Label" value="Label" onChange={onChange} />
-      <Textarea value="Error" error="There's a snake in my boots" onChange={onChange} />
       <Textarea
+        id="Placeholder"
+        label="Textarea with placeholder"
+        hideLabel
+        value="placeholder"
+        placeholder="Placeholder"
+        onChange={onChange}
+      />
+      <Textarea
+        id="With-value"
+        label="Textarea with value"
+        hideLabel
+        value="With value"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Disabled"
+        label="Disabled textarea"
+        hideLabel
+        value="Disabled"
+        disabled
+        onChange={onChange}
+      />
+      <Textarea id="Label" label="Label" value="Label" onChange={onChange} />
+      <Textarea
+        id="Error"
+        label="Textarea with error"
+        hideLabel
+        value="Error"
+        error="There's a snake in my boots"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Label-and-error"
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"
@@ -33,21 +88,43 @@ storiesOf('Design System|forms/Textarea', module)
   .add('secondary', () => (
     <form style={{ background: '#fff', padding: '3em' }}>
       <Textarea
+        id="Placeholder"
+        label="Textarea with placeholder"
+        hideLabel
         value="placeholder"
         placeholder="Placeholder"
         appearance="secondary"
         onChange={onChange}
       />
-      <Textarea value="With value" appearance="secondary" onChange={onChange} />
-      <Textarea value="Disabled" disabled appearance="secondary" onChange={onChange} />
-      <Textarea label="Label" value="Label" appearance="secondary" onChange={onChange} />
       <Textarea
+        id="With-value"
+        label="Textarea with value"
+        hideLabel
+        value="With value"
+        appearance="secondary"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Disabled"
+        label="Disabled textarea"
+        hideLabel
+        value="Disabled"
+        disabled
+        appearance="secondary"
+        onChange={onChange}
+      />
+      <Textarea id="Label" label="Label" value="Label" appearance="secondary" onChange={onChange} />
+      <Textarea
+        id="Error"
+        label="Textarea with error"
+        hideLabel
         value="Error"
         error="There's a snake in my boots"
         appearance="secondary"
         onChange={onChange}
       />
       <Textarea
+        id="Label-and-error"
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"
@@ -59,21 +136,43 @@ storiesOf('Design System|forms/Textarea', module)
   .add('tertiary', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
       <Textarea
+        id="Placeholder"
+        label="Textarea with placeholder"
+        hideLabel
         value="placeholder"
         placeholder="Placeholder"
         appearance="tertiary"
         onChange={onChange}
       />
-      <Textarea value="With value" appearance="tertiary" onChange={onChange} />
-      <Textarea value="Disabled" disabled appearance="tertiary" onChange={onChange} />
-      <Textarea label="Label" value="Label" appearance="tertiary" onChange={onChange} />
       <Textarea
+        id="With-value"
+        label="Textarea with value"
+        hideLabel
+        value="With value"
+        appearance="tertiary"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Disabled"
+        label="Disabled textarea"
+        hideLabel
+        value="Disabled"
+        disabled
+        appearance="tertiary"
+        onChange={onChange}
+      />
+      <Textarea id="Label" label="Label" value="Label" appearance="tertiary" onChange={onChange} />
+      <Textarea
+        id="Error"
+        label="Textarea with error"
+        hideLabel
         value="Error"
         error="There's a snake in my boots"
         appearance="tertiary"
         onChange={onChange}
       />
       <Textarea
+        id="Label-and-error"
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"
@@ -85,16 +184,35 @@ storiesOf('Design System|forms/Textarea', module)
   .add('code', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
       <Textarea
+        id="Placeholder"
+        label="Textarea with placeholder"
+        hideLabel
         value="placeholder"
         placeholder="Code placeholder"
         appearance="code"
         onChange={onChange}
       />
-      <Textarea value="Code" appearance="code" onChange={onChange} />
-      <Textarea value="Code" appearance="code" error="Does not compute" onChange={onChange} />
-      <Textarea label="Label" value="Label" appearance="code" onChange={onChange} />
+      <Textarea
+        id="With-value"
+        label="Textarea with value"
+        hideLabel
+        value="Code"
+        appearance="code"
+        onChange={onChange}
+      />
+      <Textarea
+        id="Error"
+        label="Textarea with error"
+        hideLabel
+        value="Code"
+        appearance="code"
+        error="Does not compute"
+        onChange={onChange}
+      />
+      <Textarea id="Label" label="Label" value="Label" appearance="code" onChange={onChange} />
 
       <Textarea
+        id="Label-and-error"
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"
@@ -102,13 +220,15 @@ storiesOf('Design System|forms/Textarea', module)
         onChange={onChange}
       />
       <Textarea
-        value="Label and error"
+        id="Label-horizontal"
+        value="Label"
         label="Cats"
         appearance="code"
         orientation="horizontal"
         onChange={onChange}
       />
       <Textarea
+        id="Label-and-error-horizontal"
         value="Label and error"
         label="Cats"
         error="There's a snake in my boots"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Textarea component is not accessible.
1. label semantic is not correct.
2. labels are not associated to the textarea. Focusing on the textarea, SR won't read the label.
3. labels are not required.
4. invalid textarea should have aria-invalid attribute.
5. errors are not associated to textarea. Focusing on the textarea, SR won't read the error.
6. error is before the textarea. SR will read it, but blind people don't know that there is an associated textarea until they focus on the next element. It lacks some context.
7. subtext is not associated to the textarea

**What is the chosen solution to this problem?**
1. use `<label>`
2. accept a required props `id` that is passed to the textarea. Use `htmlFor` react attribute to associate the label with the textarea through the id.
3. labels are required, introducing a `hideLabel` props if we want it not to be displayed.
4. add aria-invalid attribute on textarea with error
5. generate an error id based on the props.id, that is passed to the error element. Use `aria-describedby` on the textarea to associate the error with it.
6. hide the error from SR. It is still associated to the textarea, focusing on it will make SR read the error too. 
7. same as error, generate an id and associate it via `aria-describedby`