### PR TITLE
fix: checkbox accessibility

### DIFF
--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -79,6 +79,10 @@ const Input = styled.input.attrs({ type: 'checkbox' })`
     box-shadow: ${color.mediumdark} 0 0 0 1px inset;
   }
 
+  &:focus + ${LabelText}:before {
+    box-shadow: ${color.primary} 0 0 0 1px inset;
+  }
+
   &:checked + ${LabelText}:before {
     box-shadow: ${color.primary} 0 0 0 1px inset;
   }

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { color, typography } from './shared/styles';
+
+const CheckboxWrapper = styled.div``;
 
 const Label = styled.label`
   cursor: pointer;
@@ -13,15 +15,39 @@ const Label = styled.label`
 
 const Error = styled.span`
   font-weight: ${typography.weight.regular};
+  font-size: ${typography.size.s2}px;
   color: ${color.negative};
   margin-left: 6px;
+  vertical-align: text-top;
+  min-height: 1em;
+
+  ${props =>
+    !props.error &&
+    css`
+      margin: 0;
+    `}
 `;
 
-const LabelText = styled.span``;
+const LabelText = styled.span`
+  ${props =>
+    props.hideLabel &&
+    css`
+      border: 0px !important;
+      clip: rect(0 0 0 0) !important;
+      -webkit-clip-path: inset(100%) !important;
+      clip-path: inset(100%) !important;
+      height: 1px !important;
+      overflow: hidden !important;
+      padding: 0px !important;
+      position: absolute !important;
+      white-space: nowrap !important;
+      width: 1px !important;
+    `}
+`;
 
 const Input = styled.input.attrs({ type: 'checkbox' })`
   margin: 0 0.6em 0 0;
-  visibility: hidden;
+  opacity: 0;
 
   & + ${LabelText} {
     display: inline-block;
@@ -75,24 +101,35 @@ const Input = styled.input.attrs({ type: 'checkbox' })`
   }
 `;
 
-export function Checkbox({ label, error, ...props }) {
+export function Checkbox({ id, label, error, hideLabel, ...props }) {
+  const errorId = `${id}-error`;
   return (
-    <Label>
-      <Input {...props} type="checkbox" />
-      <LabelText>
-        {label}
-        {error && <Error>{error}</Error>}
-      </LabelText>
-    </Label>
+    <CheckboxWrapper>
+      <Label>
+        <Input
+          {...props}
+          id={id}
+          aria-describedby={errorId}
+          aria-invalid={!!error}
+          type="checkbox"
+        />
+        <LabelText hideLabel={hideLabel}>{label}</LabelText>
+      </Label>
+      <Error id={errorId} error={error}>
+        {error}
+      </Error>
+    </CheckboxWrapper>
   );
 }
 
 Checkbox.propTypes = {
-  label: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  hideLabel: PropTypes.bool,
   error: PropTypes.string,
 };
 
 Checkbox.defaultProps = {
-  label: null,
+  hideLabel: false,
   error: null,
 };

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -48,6 +48,7 @@ const LabelText = styled.span``;
 const Input = styled.input.attrs({ type: 'checkbox' })`
   margin: 0 0.6em 0 0;
   opacity: 0;
+  vertical-align: text-top;
 
   & + ${LabelText} {
     display: inline-block;

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { color, typography } from './shared/styles';
 
-const CheckboxWrapper = styled.div``;
-
 const Label = styled.label`
   cursor: pointer;
   font-size: ${typography.size.s2}px;
@@ -106,7 +104,7 @@ const Input = styled.input.attrs({ type: 'checkbox' })`
 export function Checkbox({ id, label, error, hideLabel, ...props }) {
   const errorId = `${id}-error`;
   return (
-    <CheckboxWrapper>
+    <React.Fragment>
       <Label>
         <Input
           {...props}
@@ -122,7 +120,7 @@ export function Checkbox({ id, label, error, hideLabel, ...props }) {
       <Error id={errorId} error={error}>
         {error}
       </Error>
-    </CheckboxWrapper>
+    </React.Fragment>
   );
 }
 

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -13,22 +13,7 @@ const Label = styled.label`
   position: relative;
 `;
 
-const Error = styled.span`
-  font-weight: ${typography.weight.regular};
-  font-size: ${typography.size.s2}px;
-  color: ${color.negative};
-  margin-left: 6px;
-  vertical-align: text-top;
-  min-height: 1em;
-
-  ${props =>
-    !props.error &&
-    css`
-      margin: 0;
-    `}
-`;
-
-const LabelText = styled.span`
+const OptionalText = styled.span`
   ${props =>
     props.hideLabel &&
     css`
@@ -44,6 +29,23 @@ const LabelText = styled.span`
       width: 1px !important;
     `}
 `;
+
+const Error = styled.span`
+  font-weight: ${typography.weight.regular};
+  font-size: ${typography.size.s2}px;
+  color: ${color.negative};
+  margin-left: 6px;
+  vertical-align: text-top;
+  min-height: 1em;
+
+  ${props =>
+    !props.error &&
+    css`
+      margin: 0;
+    `}
+`;
+
+const LabelText = styled.span``;
 
 const Input = styled.input.attrs({ type: 'checkbox' })`
   margin: 0 0.6em 0 0;
@@ -113,7 +115,9 @@ export function Checkbox({ id, label, error, hideLabel, ...props }) {
           aria-invalid={!!error}
           type="checkbox"
         />
-        <LabelText hideLabel={hideLabel}>{label}</LabelText>
+        <LabelText>
+          <OptionalText hideLabel={hideLabel}>{label}</OptionalText>
+        </LabelText>
       </Label>
       <Error id={errorId} error={error}>
         {error}

--- a/src/components/Checkbox.stories.js
+++ b/src/components/Checkbox.stories.js
@@ -11,13 +11,13 @@ storiesOf('Design System|forms/Checkbox', module)
     <form>
       <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />
       <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
-      <Checkbox id="With-label" label="Cats" onChange={onChange} />
       <Checkbox
         id="With-label-and-error"
         label="Cats"
         onChange={onChange}
         error="There's a snake in my boots"
       />
+      <Checkbox id="With-label" label="Cats" onChange={onChange} />
     </form>
   ))
   .add('unchecked', () => <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />)

--- a/src/components/Checkbox.stories.js
+++ b/src/components/Checkbox.stories.js
@@ -9,11 +9,26 @@ storiesOf('Design System|forms/Checkbox', module)
   .addParameters({ component: Checkbox })
   .add('all checkboxes', () => (
     <form>
-      <Checkbox onChange={onChange} />
-      <Checkbox checked onChange={onChange} />
-      <Checkbox label="Cats" onChange={onChange} error="There's a snake in my boots" />
-      <Checkbox label="Cats" onChange={onChange} />
+      <div>
+        <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />
+      </div>
+      <div>
+        <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
+      </div>
+      <div>
+        <Checkbox id="With-label" label="Cats" onChange={onChange} />
+      </div>
+      <div>
+        <Checkbox
+          id="With-label-and-error"
+          label="Cats"
+          onChange={onChange}
+          error="There's a snake in my boots"
+        />
+      </div>
     </form>
   ))
-  .add('unchecked', () => <Checkbox onChange={onChange} />)
-  .add('checked', () => <Checkbox checked onChange={onChange} />);
+  .add('unchecked', () => <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />)
+  .add('checked', () => (
+    <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
+  ));

--- a/src/components/Checkbox.stories.js
+++ b/src/components/Checkbox.stories.js
@@ -9,23 +9,15 @@ storiesOf('Design System|forms/Checkbox', module)
   .addParameters({ component: Checkbox })
   .add('all checkboxes', () => (
     <form>
-      <div>
-        <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />
-      </div>
-      <div>
-        <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
-      </div>
-      <div>
-        <Checkbox id="With-label" label="Cats" onChange={onChange} />
-      </div>
-      <div>
-        <Checkbox
-          id="With-label-and-error"
-          label="Cats"
-          onChange={onChange}
-          error="There's a snake in my boots"
-        />
-      </div>
+      <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />
+      <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
+      <Checkbox id="With-label" label="Cats" onChange={onChange} />
+      <Checkbox
+        id="With-label-and-error"
+        label="Cats"
+        onChange={onChange}
+        error="There's a snake in my boots"
+      />
     </form>
   ))
   .add('unchecked', () => <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Checkbox component is not accessible
1. non focusable and ignored by SR because of `visibility: hidden`
2. label is not required
3. errors are set as labels
4. checkbox with errors are not set as invalid
5. missing focus visual aspect for keyboard navigation

**What is the chosen solution to this problem?**
1. make input visible again, but outside of viewport
2. label is required, introducing `hideLabel` props. Be careful to give a clear context when you hide the label in the designs
3. errors are in a div next to the label, associated with input via `aria-describedby`
4. use `aria-invalid` on input when there is an error
5. TODO