### PR TITLE
Only pass appropriate link props to Tooltip ListItem

### DIFF
--- a/src/components/StoryLinkWrapper.js
+++ b/src/components/StoryLinkWrapper.js
@@ -6,15 +6,15 @@ import { action } from '@storybook/addon-actions';
 
 const fireClickAction = action('onLinkClick');
 
-export function StoryLinkWrapper({ children, href, onClick, ...rest }) {
+export function StoryLinkWrapper({ children, className, href, onClick, to }) {
   const modifiedOnClick = event => {
     event.preventDefault();
     onClick();
-    fireClickAction(href);
+    fireClickAction(href || to);
   };
 
   return (
-    <a href={href} {...rest} onClick={modifiedOnClick}>
+    <a className={className} href={href || to} onClick={modifiedOnClick}>
       {children}
     </a>
   );
@@ -23,10 +23,15 @@ export function StoryLinkWrapper({ children, href, onClick, ...rest }) {
 StoryLinkWrapper.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   children: PropTypes.any.isRequired,
-  href: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  href: PropTypes.string,
   onClick: PropTypes.func,
+  to: PropTypes.string,
 };
 
 StoryLinkWrapper.defaultProps = {
+  className: '',
+  href: null,
   onClick: () => {},
+  to: null,
 };

--- a/src/components/tooltip/ListItem.js
+++ b/src/components/tooltip/ListItem.js
@@ -52,7 +52,8 @@ const ItemInner = styled.span`
   }
 `;
 
-const Item = styled.a`
+// eslint-disable-next-line jsx-a11y/anchor-has-content
+const Item = styled(({ active, loading, ...rest }) => <a {...rest} />)`
   font-size: ${typography.size.s1}px;
   transition: all 150ms ease-out;
   color: ${color.mediumdark};


### PR DESCRIPTION
This is to avoid PropType errors like this:

![Screen Shot 2019-06-20 at 2 33 40 PM](https://user-images.githubusercontent.com/3035355/59879668-762c3000-9368-11e9-88ef-916505cf629e.png)

Links are weird about passing things down.