### PR TITLE
fix: radio accessiblity

### DIFF
--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -1,25 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { rgba } from 'polished';
 import { color, typography } from './shared/styles';
 
 const Label = styled.label`
   cursor: pointer;
   font-size: ${typography.size.s2}px;
   font-weight: ${typography.weight.bold};
-  min-height: 1em;
   position: relative;
-  display: block;
+  display: inline-block;
+  height: 1em;
+`;
+
+const OptionalText = styled.span`
+  display: inline-block;
+  line-height: 1em;
+  ${props =>
+    props.hideLabel &&
+    css`
+      border: 0px !important;
+      clip: rect(0 0 0 0) !important;
+      -webkit-clip-path: inset(100%) !important;
+      clip-path: inset(100%) !important;
+      height: 1px !important;
+      overflow: hidden !important;
+      padding: 0px !important;
+      position: absolute !important;
+      white-space: nowrap !important;
+      width: 1px !important;
+    `}
 `;
 
 const Error = styled.span`
   font-weight: ${typography.weight.regular};
+  font-size: ${typography.size.s2}px;
   color: ${color.negative};
   margin-left: 6px;
+  vertical-align: text-top;
+  height: 1em;
+  display: inline-block;
+
+  ${props =>
+    !props.error &&
+    css`
+      margin: 0;
+    `}
 `;
 
-const LabelText = styled.div``;
-const SublabelText = styled.div`
+const LabelText = styled.span``;
+
+const SubLabelText = styled.div`
   font-size: ${typography.size.s1}px;
   font-weight: ${typography.weight.regular};
   margin-top: 4px;
@@ -27,14 +58,14 @@ const SublabelText = styled.div`
 `;
 
 const Input = styled.input.attrs({ type: 'radio' })`
-  float: left;
   margin: 0 0.6em 0 0;
-  visibility: hidden;
+  opacity: 0;
+  vertical-align: text-top;
 
   & + ${LabelText} {
-    display: block;
-    line-height: 1;
-    overflow: hidden;
+    display: inline-block;
+    vertical-align: text-top;
+    line-height: 1.2;
 
     &:before,
     &:after {
@@ -54,8 +85,16 @@ const Input = styled.input.attrs({ type: 'radio' })`
     box-shadow: ${color.mediumdark} 0 0 0 1px inset;
   }
 
+  &:focus + ${LabelText}:before {
+    box-shadow: ${color.primary} 0 0 0 1px inset;
+  }
+
   &:checked + ${LabelText}:before {
     box-shadow: ${color.primary} 0 0 0 1px inset;
+  }
+
+  &:checked:focus + ${LabelText}:before {
+    box-shadow: ${color.primary} 0 0 0 1px inset, ${rgba(color.primary, 0.3)} 0 0 5px 2px;
   }
 
   & + ${LabelText}:after {
@@ -76,24 +115,38 @@ const Input = styled.input.attrs({ type: 'radio' })`
   }
 `;
 
-export function Radio({ value, label, sublabel, error, className, ...props }) {
+export function Radio({ id, label, subLabel, error, hideLabel, value, className, ...props }) {
+  const errorId = `${id}-error`;
+  const subLabelId = `${id}-subLabel`;
   return (
-    <Label className={className}>
-      <Input value={value} {...props} type="radio" />
-
-      <LabelText>
-        {label}
-        {error && <Error>{error}</Error>}
-        {sublabel && <SublabelText>{sublabel}</SublabelText>}
-      </LabelText>
-    </Label>
+    <div>
+      <Label className={className}>
+        <Input
+          {...props}
+          id={id}
+          aria-describedby={errorId}
+          aria-invalid={!!error}
+          type="radio"
+          value={value}
+        />
+        <LabelText>
+          <OptionalText hideLabel={hideLabel}>{label}</OptionalText>
+        </LabelText>
+      </Label>
+      <Error id={errorId} error={error}>
+        {error}
+      </Error>
+      <SubLabelText id={subLabelId}>{subLabel}</SubLabelText>
+    </div>
   );
 }
 
 Radio.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.string,
   label: PropTypes.string,
-  sublabel: PropTypes.string,
+  hideLabel: PropTypes.bool,
+  subLabel: PropTypes.string,
   error: PropTypes.string,
   className: PropTypes.string,
 };
@@ -101,7 +154,8 @@ Radio.propTypes = {
 Radio.defaultProps = {
   value: '',
   label: null,
-  sublabel: null,
+  hideLabel: false,
+  subLabel: null,
   error: null,
   className: null,
 };

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -4,18 +4,23 @@ import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import { color, typography } from './shared/styles';
 
+const RadioWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
 const Label = styled.label`
   cursor: pointer;
   font-size: ${typography.size.s2}px;
   font-weight: ${typography.weight.bold};
   position: relative;
-  display: inline-block;
   height: 1em;
+  display: flex;
+  align-items: center;
 `;
 
 const OptionalText = styled.span`
-  display: inline-block;
-  line-height: 1em;
   ${props =>
     props.hideLabel &&
     css`
@@ -37,15 +42,9 @@ const Error = styled.span`
   font-size: ${typography.size.s2}px;
   color: ${color.negative};
   margin-left: 6px;
-  vertical-align: text-top;
   height: 1em;
-  display: inline-block;
-
-  ${props =>
-    !props.error &&
-    css`
-      margin: 0;
-    `}
+  display: flex;
+  align-items: center;
 `;
 
 const LabelText = styled.span``;
@@ -54,26 +53,23 @@ const SubLabelText = styled.div`
   font-size: ${typography.size.s1}px;
   font-weight: ${typography.weight.regular};
   color: ${color.mediumdark};
+  margin-top: 4px;
+  width: 100%;
 `;
 
 const Input = styled.input.attrs({ type: 'radio' })`
   margin: 0 0.6em 0 0;
   opacity: 0;
-  vertical-align: text-top;
 
   & + ${LabelText} {
-    display: inline-block;
-    vertical-align: text-top;
-    line-height: 1.2;
-
     &:before,
     &:after {
       transition: all 150ms ease-out;
       position: absolute;
       top: 0;
       left: 0;
-      height: 14px;
-      width: 14px;
+      height: 1em;
+      width: 1em;
       content: '';
       display: block;
       border-radius: 3em;
@@ -115,15 +111,26 @@ const Input = styled.input.attrs({ type: 'radio' })`
 `;
 
 export function Radio({ id, label, subLabel, error, hideLabel, value, className, ...props }) {
-  const errorId = `${id}-error`;
-  const subLabelId = `${id}-subLabel`;
+  let errorId;
+  let subLabelId;
+  let ariaDescribedBy;
+
+  if (error) {
+    errorId = `${id}-error`;
+    ariaDescribedBy = errorId;
+  }
+  if (subLabel) {
+    subLabelId = `${id}-subLabel`;
+    ariaDescribedBy = `${ariaDescribedBy} ${subLabelId}`;
+  }
+
   return (
-    <div>
+    <RadioWrapper>
       <Label className={className}>
         <Input
           {...props}
           id={id}
-          aria-describedby={errorId}
+          aria-describedby={ariaDescribedBy}
           aria-invalid={!!error}
           type="radio"
           value={value}
@@ -132,11 +139,9 @@ export function Radio({ id, label, subLabel, error, hideLabel, value, className,
           <OptionalText hideLabel={hideLabel}>{label}</OptionalText>
         </LabelText>
       </Label>
-      <Error id={errorId} error={error}>
-        {error}
-      </Error>
-      <SubLabelText id={subLabelId}>{subLabel}</SubLabelText>
-    </div>
+      {error && <Error id={errorId}>{error}</Error>}
+      {subLabel && <SubLabelText id={subLabelId}>{subLabel}</SubLabelText>}
+    </RadioWrapper>
   );
 }
 

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -53,7 +53,6 @@ const LabelText = styled.span``;
 const SubLabelText = styled.div`
   font-size: ${typography.size.s1}px;
   font-weight: ${typography.weight.regular};
-  margin-top: 4px;
   color: ${color.mediumdark};
 `;
 

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -4,12 +4,6 @@ import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import { color, typography } from './shared/styles';
 
-const RadioWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-`;
-
 const Label = styled.label`
   cursor: pointer;
   font-size: ${typography.size.s2}px;
@@ -54,17 +48,18 @@ const Description = styled.div`
   font-weight: ${typography.weight.regular};
   color: ${color.mediumdark};
   margin-top: 4px;
+  margin-left: calc(${typography.size.s2}px + 0.4em);
   width: 100%;
 `;
 
 const Input = styled.input.attrs({ type: 'radio' })`
-  margin: 0 0.6em 0 0;
+  margin: 0 0.4em 0 0;
+  font-size: initial;
   opacity: 0;
 
   & + ${LabelText} {
     &:before,
     &:after {
-      transition: all 150ms ease-out;
       position: absolute;
       top: 0;
       left: 0;
@@ -93,6 +88,7 @@ const Input = styled.input.attrs({ type: 'radio' })`
   }
 
   & + ${LabelText}:after {
+    transition: all 150ms ease-out;
     transform: scale3d(0, 0, 1);
 
     height: 10px;
@@ -108,6 +104,12 @@ const Input = styled.input.attrs({ type: 'radio' })`
     background: ${color.primary};
     opacity: 1;
   }
+`;
+
+const RadioWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 `;
 
 export function Radio({ id, label, description, error, hideLabel, value, className, ...props }) {

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -49,7 +49,7 @@ const Error = styled.span`
 
 const LabelText = styled.span``;
 
-const SubLabelText = styled.div`
+const Description = styled.div`
   font-size: ${typography.size.s1}px;
   font-weight: ${typography.weight.regular};
   color: ${color.mediumdark};
@@ -110,18 +110,18 @@ const Input = styled.input.attrs({ type: 'radio' })`
   }
 `;
 
-export function Radio({ id, label, subLabel, error, hideLabel, value, className, ...props }) {
+export function Radio({ id, label, description, error, hideLabel, value, className, ...props }) {
   let errorId;
-  let subLabelId;
+  let descriptionId;
   let ariaDescribedBy;
 
   if (error) {
     errorId = `${id}-error`;
     ariaDescribedBy = errorId;
   }
-  if (subLabel) {
-    subLabelId = `${id}-subLabel`;
-    ariaDescribedBy = `${ariaDescribedBy} ${subLabelId}`;
+  if (description) {
+    descriptionId = `${id}-description`;
+    ariaDescribedBy = `${ariaDescribedBy} ${descriptionId}`;
   }
 
   return (
@@ -140,7 +140,7 @@ export function Radio({ id, label, subLabel, error, hideLabel, value, className,
         </LabelText>
       </Label>
       {error && <Error id={errorId}>{error}</Error>}
-      {subLabel && <SubLabelText id={subLabelId}>{subLabel}</SubLabelText>}
+      {description && <Description id={descriptionId}>{description}</Description>}
     </RadioWrapper>
   );
 }
@@ -150,7 +150,7 @@ Radio.propTypes = {
   value: PropTypes.string,
   label: PropTypes.string,
   hideLabel: PropTypes.bool,
-  subLabel: PropTypes.string,
+  description: PropTypes.string,
   error: PropTypes.string,
   className: PropTypes.string,
 };
@@ -159,7 +159,7 @@ Radio.defaultProps = {
   value: '',
   label: null,
   hideLabel: false,
-  subLabel: null,
+  description: null,
   error: null,
   className: null,
 };

--- a/src/components/Radio.stories.js
+++ b/src/components/Radio.stories.js
@@ -12,7 +12,7 @@ storiesOf('Design System|forms/Radio', module)
       <Radio id="Mice" label="Mice" value="mice" checked onChange={onChange} />
       <Radio id="Dogs" label="Dogs" value="dogs" onChange={onChange} />
       <Radio id="Cats" label="Cats" onChange={onChange} error="There's a snake in my boots" />
-      <Radio id="Dogs" label="Dogs" subLabel="15 canines" value="dogs" onChange={onChange} />
+      <Radio id="Dogs" label="Dogs" description="15 canines" value="dogs" onChange={onChange} />
     </form>
   ))
   .add('unchecked', () => (

--- a/src/components/Radio.stories.js
+++ b/src/components/Radio.stories.js
@@ -9,11 +9,28 @@ storiesOf('Design System|forms/Radio', module)
   .addParameters({ component: Radio })
   .add('all radios', () => (
     <form>
-      <Radio label="Mice" value="mice" checked onChange={onChange} />
-      <Radio label="Dogs" value="dogs" onChange={onChange} />
-      <Radio label="Cats" onChange={onChange} error="There's a snake in my boots" />
-      <Radio label="Dogs" sublabel="15 canines" value="dogs" onChange={onChange} />
+      <Radio id="Mice" name="animal" label="Mice" value="mice" checked onChange={onChange} />
+      <Radio id="Dogs" name="animal" label="Dogs" value="dogs" onChange={onChange} />
+      <Radio
+        id="Cats"
+        name="animal"
+        label="Cats"
+        onChange={onChange}
+        error="There's a snake in my boots"
+      />
+      <Radio
+        id="Dogs"
+        name="animal"
+        label="Dogs"
+        subLabel="15 canines"
+        value="dogs"
+        onChange={onChange}
+      />
     </form>
   ))
-  .add('unchecked', () => <Radio value="mice" onChange={onChange} />)
-  .add('checked', () => <Radio value="dogs" checked onChange={onChange} />);
+  .add('unchecked', () => (
+    <Radio id="Mice" label="Mice" hideLabel value="mice" onChange={onChange} />
+  ))
+  .add('checked', () => (
+    <Radio id="Dogs" label="Dogs" hideLabel value="dogs" checked onChange={onChange} />
+  ));

--- a/src/components/Radio.stories.js
+++ b/src/components/Radio.stories.js
@@ -9,23 +9,10 @@ storiesOf('Design System|forms/Radio', module)
   .addParameters({ component: Radio })
   .add('all radios', () => (
     <form>
-      <Radio id="Mice" name="animal" label="Mice" value="mice" checked onChange={onChange} />
-      <Radio id="Dogs" name="animal" label="Dogs" value="dogs" onChange={onChange} />
-      <Radio
-        id="Cats"
-        name="animal"
-        label="Cats"
-        onChange={onChange}
-        error="There's a snake in my boots"
-      />
-      <Radio
-        id="Dogs"
-        name="animal"
-        label="Dogs"
-        subLabel="15 canines"
-        value="dogs"
-        onChange={onChange}
-      />
+      <Radio id="Mice" label="Mice" value="mice" checked onChange={onChange} />
+      <Radio id="Dogs" label="Dogs" value="dogs" onChange={onChange} />
+      <Radio id="Cats" label="Cats" onChange={onChange} error="There's a snake in my boots" />
+      <Radio id="Dogs" label="Dogs" subLabel="15 canines" value="dogs" onChange={onChange} />
     </form>
   ))
   .add('unchecked', () => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Radio component is not accessible
1. non focusable and ignored by SR because of `visibility: hidden`
2. label is not required
3. errors are set as labels
4. checkbox with errors are not set as invalid
5. missing focus visual aspect for keyboard navigation
6. subLabels are set as labels

**What is the chosen solution to this problem?**
1. make input visible again, but outside of viewport
2. label is required, introducing `hideLabel` props. Be careful to give a clear context when you hide the label in the designs
3. errors are in a div next to the label, associated with input via `aria-describedby`
4. use `aria-invalid` on input when there is an error
5. use the same style as checkbox for focus state
6. subLabels are not linked as descriptions. Should we rename it ?
