### PR TITLE
fix: select accessibility

### DIFF
--- a/src/components/Select.stories.js
+++ b/src/components/Select.stories.js
@@ -10,6 +10,7 @@ storiesOf('Design System|forms/Select', module)
   .add('All selects', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
       <Select
+        id="Primary"
         value="value1"
         options={[
           { label: 'Default', value: 'value1' },
@@ -17,8 +18,11 @@ storiesOf('Design System|forms/Select', module)
           { label: 'Mouse', value: 'value3' },
         ]}
         onChange={onChange}
+        label="Animal"
+        hideLabel
       />
       <Select
+        id="Secondary"
         value="value1"
         options={[
           { label: 'Secondary', value: 'value1' },
@@ -27,8 +31,11 @@ storiesOf('Design System|forms/Select', module)
         ]}
         appearance="secondary"
         onChange={onChange}
+        label="Animal"
+        hideLabel
       />
       <Select
+        id="Tertiary"
         value="value1"
         options={[
           { label: 'Tertiary', value: 'value1' },
@@ -37,29 +44,43 @@ storiesOf('Design System|forms/Select', module)
         ]}
         appearance="tertiary"
         onChange={onChange}
+        label="Animal"
+        hideLabel
       />
     </form>
   ))
   .add('default', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
       <Select
+        id="Primary"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         onChange={onChange}
       />
       <Select
+        id="Primary-disabled"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         disabled
         onChange={onChange}
       />
       <Select
+        id="Primary-with-iconn"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
         onChange={onChange}
       />
       <Select
+        id="Primary-in-progress"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -67,12 +88,18 @@ storiesOf('Design System|forms/Select', module)
         inProgress
       />
       <Select
+        id="Primary-with-error"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         error="There's a snake in my boots"
         onChange={onChange}
       />
       <Select
+        id="Primary-with-icon-and-error"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -80,6 +107,7 @@ storiesOf('Design System|forms/Select', module)
         onChange={onChange}
       />
       <Select
+        id="Primary-with-label"
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -91,12 +119,18 @@ storiesOf('Design System|forms/Select', module)
   .add('secondary', () => (
     <form style={{ background: '#FFFFFF', padding: '3em' }}>
       <Select
+        id="Secondary"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         appearance="secondary"
         onChange={onChange}
       />
       <Select
+        id="Secondary-disabled"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         disabled
@@ -104,6 +138,9 @@ storiesOf('Design System|forms/Select', module)
         onChange={onChange}
       />
       <Select
+        id="Secondary-with-icon"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -111,6 +148,9 @@ storiesOf('Design System|forms/Select', module)
         onChange={onChange}
       />
       <Select
+        id="Secondary-with-error"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         error="There's a snake in my boots"
@@ -118,6 +158,9 @@ storiesOf('Design System|forms/Select', module)
         onChange={onChange}
       />
       <Select
+        id="Secondary-with-icon-and-error"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -126,6 +169,7 @@ storiesOf('Design System|forms/Select', module)
         onChange={onChange}
       />
       <Select
+        id="Secondary-with-label"
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         icon="chroma"
@@ -138,12 +182,18 @@ storiesOf('Design System|forms/Select', module)
   .add('tertiary', () => (
     <form style={{ background: '#EEEEEE', padding: '3em' }}>
       <Select
+        id="Tertiary"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         appearance="tertiary"
         onChange={onChange}
       />
       <Select
+        id="Tertiary-disabled"
+        label="Animal"
+        hideLabel
         value="value1"
         options={[{ label: 'Default', value: 'value1' }, { label: 'Dog', value: 'value2' }]}
         disabled


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Select component is not accessible
1. label is not required
2. errors are not associated to the select
3. selects with errors are not set as invalid
4. icon is decorative but not hidden to SR
5. progress status is only visual

**What is the chosen solution to this problem?**
1. label is required, and associated to the select via `for` attribute. We introduce the `hideLabel` props. Be careful to give a clear context when you hide the label in the designs
2. errors are in a div next to the label, associated with select via `aria-describedby`
3. use `aria-invalid` on select when there is an error
4. set `aria-hidden` to the icon
6. progress has a `Loading` label, that is associated with the select as a descriptionn, so screen reader will read it on focus. The select has an `aria-busy` attribute too
