### PR TITLE
fix: icon story accessibility

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -15,6 +15,12 @@ const Path = styled.path`
   fill: currentColor;
 `;
 
+/**
+ * An Icon is a piece of visual element, but we must ensure its accessibility while using it.
+ * It can have 2 purposes:
+ * - decorative only: for example, it illustrate a label next to it. We must ensure that it is ignored by screen readers, by setting `aria-hidden` attribute (ex: <Icon icon="check" aria-hidden />)
+ * - non-decorative: it means that it delivers an information. For example, an icon as only child inn a button. The meaning can be obvious visually, but it must have a proper text alternative via `aria-label` for screen readers. (ex: <Icon icon="print" aria-label="Print this document" />)
+ */
 export function Icon({ icon, block, ...props }) {
   return (
     <Svg viewBox="0 0 1024 1024" width="20px" height="20px" block={block} {...props}>

--- a/src/components/Icon.stories.js
+++ b/src/components/Icon.stories.js
@@ -6,11 +6,11 @@ import { Icon } from './Icon';
 import { icons } from './shared/icons';
 
 const Meta = styled.div`
-  color: #999;
+  color: #666;
   font-size: 12px;
 `;
 
-const Item = styled.div`
+const Item = styled.li`
   display: inline-flex;
   flex-direction: row;
   align-items: center;
@@ -43,9 +43,10 @@ const Item = styled.div`
     `};
 `;
 
-const List = styled.div`
+const List = styled.ul`
   display: flex;
   flex-flow: row wrap;
+  list-style: none;
 `;
 
 storiesOf('Design System|Icon', module)
@@ -56,7 +57,7 @@ storiesOf('Design System|Icon', module)
       <List>
         {Object.keys(icons).map(key => (
           <Item key={key}>
-            <Icon icon={key} />
+            <Icon icon={key} aria-hidden />
             <Meta>{key}</Meta>
           </Item>
         ))}
@@ -67,18 +68,18 @@ storiesOf('Design System|Icon', module)
     <List>
       {Object.keys(icons).map(key => (
         <Item minimal key={key}>
-          <Icon icon={key} />
+          <Icon icon={key} aria-label={key} />
         </Item>
       ))}
     </List>
   ))
   .add('inline', () => (
     <Fragment>
-      this is an inline <Icon icon="facehappy" /> icon (default)
+      this is an inline <Icon icon="facehappy" aria-label="Happy face" /> icon (default)
     </Fragment>
   ))
   .add('block', () => (
     <Fragment>
-      this is a block <Icon icon="facehappy" block /> icon
+      this is a block <Icon icon="facehappy" aria-label="Happy face" block /> icon
     </Fragment>
   ));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icon story is not accessible. This is only on the story as we can’t do anything to ensure icon accessibility, it’s more linked to the usage.
On decorative icons we should hide it via `aria-hidden`, and on icons that hold information, we should set a proper `aria-label`.

1. it’s a list but it only uses divs
2. story with label has `decorative` icons, they should be hidden to SR
3. story without labels icons hold information, they should have some text alternatives
4. stories with inline/block icon should have a text alternative

**What is the chosen solution to this problem?**
1. use ul/li
2. add aria-hidden on the icons
3. set key as `aria-label`
4. set a meaningful `aria-label`

As suggested by @domyen, a comment in Icon code has been added, giving advice to make it accessible when using it.