### PR TITLE
Refactor Highlight CSS loading to avoid css-loader expectation

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -5,15 +5,19 @@ import styled from 'styled-components';
 import Prism from 'prismjs';
 import loadLanguages from 'prismjs/components/index';
 import PropTypes from 'prop-types';
-
 import { color, typography } from './shared/styles';
-
-import 'prismjs/themes/prism.css';
 
 loadLanguages(['bash', 'typescript', 'json']);
 
-// Tweak Prism styling
+// Prism theme copied from 'prismjs/themes/prism.css.' -- without Webpack, the CSS
+// cannot be imported easily and any app which pulls in the design system will
+// need to handle the CSS loading itself. Therefore, it is easiest to just copy
+// the theme over.
+// prettier-ignore
 const HighlightBlock = styled.div`
+  /* Theme below from: prismjs/themes/prism.css */
+  code[class*=language-],pre[class*=language-]{color:#000;background:0 0;text-shadow:0 1px #fff;font-family:Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}code[class*=language-] ::-moz-selection,code[class*=language-]::-moz-selection,pre[class*=language-] ::-moz-selection,pre[class*=language-]::-moz-selection{text-shadow:none;background:#b3d4fc}code[class*=language-] ::selection,code[class*=language-]::selection,pre[class*=language-] ::selection,pre[class*=language-]::selection{text-shadow:none;background:#b3d4fc}@media print{code[class*=language-],pre[class*=language-]{text-shadow:none}}pre[class*=language-]{padding:1em;margin:.5em 0;overflow:auto}:not(pre)>code[class*=language-],pre[class*=language-]{background:#f5f2f0}:not(pre)>code[class*=language-]{padding:.1em;border-radius:.3em;white-space:normal}.token.cdata,.token.comment,.token.doctype,.token.prolog{color:#708090}.token.punctuation{color:#999}.namespace{opacity:.7}.token.boolean,.token.constant,.token.deleted,.token.number,.token.property,.token.symbol,.token.tag{color:#905}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#690}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url{color:#a67f59;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.class-name,.token.function{color:#dd4a68}.token.important,.token.regex,.token.variable{color:#e90}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
+
   *:not(pre) > code[class*='language-'],
   pre[class*='language-'] {
     background: ${color.lighter};


### PR DESCRIPTION
An interesting thing happened when I was trying to import this design system into another app -- the CSS file in the `Highlight` component was throwing errors as if it could not be loaded properly. I've realized that there is not an issue w/ this in Storybook as they have their own CSS loader and so does Gatsby (which is why it didn't come up during the learnstorybook.com development).

Therefore, I have decided to just copy over the prism CSS theme rather than try to import the CSS file for a few reasons:

1. The build process in this repo does not utilize webpack, so it would be more difficult to add that in addition to the `css-loader`
2. There did not seem to be a babel equivalent to webpack's `css-loader` that I could use instead (we build the design system w/ babel and not webpack)
3. It seems like we should not assume that the consumers of this design system should have to set up the `css-loader`