### PR TITLE
Update Icon comments for formatting in docs mode

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -18,8 +18,9 @@ const Path = styled.path`
 /**
  * An Icon is a piece of visual element, but we must ensure its accessibility while using it.
  * It can have 2 purposes:
- * - decorative only: for example, it illustrate a label next to it. We must ensure that it is ignored by screen readers, by setting `aria-hidden` attribute (ex: <Icon icon="check" aria-hidden />)
- * - non-decorative: it means that it delivers an information. For example, an icon as only child inn a button. The meaning can be obvious visually, but it must have a proper text alternative via `aria-label` for screen readers. (ex: <Icon icon="print" aria-label="Print this document" />)
+ *
+ * - *decorative only*: for example, it illustrates a label next to it. We must ensure that it is ignored by screen readers, by setting `aria-hidden` attribute (ex: `<Icon icon="check" aria-hidden />`)
+ * - *non-decorative*: it means that it delivers information. For example, an icon as only child in a button. The meaning can be obvious visually, but it must have a proper text alternative via `aria-label` for screen readers. (ex: `<Icon icon="print" aria-label="Print this document" />`)
  */
 export function Icon({ icon, block, ...props }) {
   return (


### PR DESCRIPTION
Hey @jsomsanith , we have been trying to play around w/ the new docs mode features for Storybook (they are currently in alpha) and I noticed that the comment you wrote about the `Icon` is getting pulled into the docs:

![Screen Shot 2019-06-26 at 9 19 30 AM](https://user-images.githubusercontent.com/3035355/60192701-912cf300-97f3-11e9-9ac9-6d7eceb0f52e.png)

w/ just a few lil tweaks in this PR, I changed the formatting to this:

![Screen Shot 2019-06-26 at 9 19 40 AM](https://user-images.githubusercontent.com/3035355/60192759-aa35a400-97f3-11e9-91c1-6872a9b295c4.png)

What do you think? Wanted to share so you can see how easy it is to get the docs over into Storybook for the accessibility help that you are providing. Maybe you already knew? 😄 

It works with `propTypes` as well:

```
Icon.propTypes = {
  /**
   Explain the icon propType in a comment like this!
  */
  icon: PropTypes.string.isRequired,
};
```
