### PR TITLE
Update outline button appearance shadow to secondary color

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -239,10 +239,16 @@ const ButtonWrapper = styled.button`
             color: ${color.darkest};
           }
           &:focus {
-            box-shadow: ${color.medium} 0 0 0 1px inset, ${rgba(color.primary, 0.4)} 0 1px 9px 2px;
+            box-shadow: ${color.medium} 0 0 0 1px inset, ${rgba(
+          color.secondary,
+          0.4
+        )} 0 1px 9px 2px;
           }
           &:focus:hover {
-            box-shadow: ${color.medium} 0 0 0 1px inset, ${rgba(color.primary, 0.2)} 0 8px 18px 0px;
+            box-shadow: ${color.medium} 0 0 0 1px inset, ${rgba(
+          color.secondary,
+          0.2
+        )} 0 8px 18px 0px;
           }
         `};
     `};


### PR DESCRIPTION
Self explanatory. The outline button had a red focus shadow. I suspect this is because the primary color of the design system is different than the primary color of where this button was originally implemented.

Easy fix!