### PR TITLE
Fix Input, TextArea label font weight

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -7,7 +7,7 @@ import { Icon } from './Icon';
 
 // prettier-ignore
 const Label = styled.label`
-  font-weight: ${props => props.appearance !== 'code' && typography.weight.extrabold};
+  font-weight: ${props => props.appearance !== 'code' && typography.weight.bold};
   font-family: ${props => props.appearance === 'code' && typography.type.code };
   font-size: ${props => props.appearance === 'code' ? typography.size.s1 : typography.size.s2 }px;
 `;

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -7,7 +7,7 @@ import { Icon } from './Icon';
 import { Spinner } from './Spinner';
 
 const Label = styled.label`
-  font-weight: ${typography.weight.extrabold};
+  font-weight: ${typography.weight.bold};
   font-size: ${typography.size.s2}px;
 `;
 

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -27,7 +27,7 @@ const ErrorMessage = styled.span`
 
 const LabelWrapper = styled.div`
   margin-bottom: ${props => (props.appearance === 'code' ? 0.5 : 0.33)}em;
-  font-weight: ${props => props.appearance !== 'code' && typography.weight.extrabold};
+  font-weight: ${props => props.appearance !== 'code' && typography.weight.bold};
   font-family: ${props => props.appearance === 'code' && typography.type.code};
   font-size: ${props => (props.appearance === 'code' ? typography.size.s1 : typography.size.s2)}px;
 

--- a/src/components/tooltip/ListItem.js
+++ b/src/components/tooltip/ListItem.js
@@ -95,7 +95,7 @@ const Item = styled(({ active, loading, ...rest }) => <a {...rest} />)`
     props.active &&
     css`
       ${Title} {
-        font-weight: ${typography.weight.extrabold};
+        font-weight: ${typography.weight.bold};
       }
       ${Title}, ${Center} {
         color: ${color.primary};


### PR DESCRIPTION
`extrabold` does not exist anymore, so the `Input` and `TextArea` were not using the appropriate var for setting their font weight.

Found a few other places w/ the same issue.