### PR TITLE
fix: link stories accessibility

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -135,6 +135,9 @@ const LinkButton = styled.button`
   ${linkStyles};
 `;
 
+/**
+ * Links can contains text and/or icons. Be careful using only icons, you must provide a text alternative via aria-label for accessibility.
+ */
 export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children, ...rest }) {
   const content = (
     <Fragment>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -132,6 +132,15 @@ const LinkA = styled.a`
 `;
 
 const LinkButton = styled.button`
+  /* reset button styles */
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
   ${linkStyles};
 `;
 

--- a/src/components/Link.stories.js
+++ b/src/components/Link.stories.js
@@ -34,12 +34,12 @@ storiesOf('Design System|Link', module)
       </Link>
       <br />
       <Link href="https://learnstorybook.com">
-        <Icon icon="discord" />
+        <Icon icon="discord" aria-hidden />
         With icon in front
       </Link>
       <br />
-      <Link containsIcon to="https://learnstorybook.com">
-        <Icon icon="sidebar" />
+      <Link containsIcon href="https://learnstorybook.com" aria-label="Toggle side bar">
+        <Icon icon="sidebar" aria-hidden />
       </Link>
       <br />
       <Link containsIcon withArrow href="https://learnstorybook.com">


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Link stories are not accessible. This is only on the stories.
1. links with icon only don’t have text alternative
2. color contrast is not correct
3. last example (ListWrapper) is weird, having a button inside an anchor

**What is the chosen solution to this problem?**
1. add aria-label on link and add documentation
2. TODO
3. TODO: change the story
