### PR TITLE
Fix Link containsIcon specificity

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -35,6 +35,19 @@ const linkStyles = css`
   }
 
   ${props =>
+    props.containsIcon &&
+    css`
+      svg {
+        height: 1em;
+        width: 1em;
+        vertical-align: middle;
+        position: relative;
+        bottom: 0;
+        margin-right: 0;
+      }
+    `};
+
+  ${props =>
     props.secondary &&
     css`
       color: ${color.mediumdark};
@@ -112,19 +125,6 @@ const LinkInner = styled.span`
         vertical-align: inherit;
       }
     `};
-
-  ${props =>
-    props.containsIcon &&
-    css`
-      svg {
-        height: 1em;
-        width: 1em;
-        vertical-align: middle;
-        position: relative;
-        bottom: 0;
-        margin-right: 0;
-      }
-    `};
 `;
 
 const LinkA = styled.a`
@@ -147,10 +147,10 @@ const LinkButton = styled.button`
 /**
  * Links can contains text and/or icons. Be careful using only icons, you must provide a text alternative via aria-label for accessibility.
  */
-export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children, ...rest }) {
+export function Link({ isButton, withArrow, LinkWrapper, children, ...rest }) {
   const content = (
     <Fragment>
-      <LinkInner withArrow={withArrow} containsIcon={containsIcon}>
+      <LinkInner withArrow={withArrow}>
         {children}
         {withArrow && <Icon icon="arrowright" />}
       </LinkInner>
@@ -159,7 +159,7 @@ export function Link({ isButton, withArrow, containsIcon, LinkWrapper, children,
 
   if (LinkWrapper) {
     const StyledLinkWrapper = styled(
-      ({ inverse, nochrome, secondary, tertiary, ...linkWrapperRest }) => (
+      ({ containsIcon, inverse, nochrome, secondary, tertiary, ...linkWrapperRest }) => (
         <LinkWrapper {...linkWrapperRest} />
       )
     )`


### PR DESCRIPTION
The way that the `containsIcon` styles were being applied was having an effect on their priority and therefore, they were never being utilized (they are the crossed out ones):
![Screen Shot 2019-06-27 at 11 14 45 AM](https://user-images.githubusercontent.com/3035355/60286583-1506de00-98cd-11e9-921e-81ce19b9bcca.png)

I moved them around a bit so that they will take priority when that prop is passed in.

