### PR TITLE
Export spinner so it can be consumed

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ export * from './Icon';
 export * from './Link';
 export * from './Subheading';
 export * from './ProgressDots';
+export * from './Spinner';
 
 export * from './Input';
 export * from './Textarea';


### PR DESCRIPTION
Spinner was not being exported, so it threw some errors when I tried to import and use it.