### PR TITLE
Refactor tooltip ListItem for flexibility in to/href prop names

### DIFF
--- a/src/components/StoryLinkWrapper.js
+++ b/src/components/StoryLinkWrapper.js
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions';
 
 const fireClickAction = action('onLinkClick');
 
-export function StoryLinkWrapper({ children, className, href, onClick, to }) {
+export function StoryLinkWrapper({ children, className, href, onClick, to, ...rest }) {
   const modifiedOnClick = event => {
     event.preventDefault();
     onClick();
@@ -14,7 +14,7 @@ export function StoryLinkWrapper({ children, className, href, onClick, to }) {
   };
 
   return (
-    <a className={className} href={href || to} onClick={modifiedOnClick}>
+    <a className={className} href={href || to} onClick={modifiedOnClick} {...rest}>
       {children}
     </a>
   );

--- a/src/components/tooltip/ListItem.js
+++ b/src/components/tooltip/ListItem.js
@@ -52,8 +52,7 @@ const ItemInner = styled.span`
   }
 `;
 
-// eslint-disable-next-line jsx-a11y/anchor-has-content
-const Item = styled(({ active, loading, ...rest }) => <a {...rest} />)`
+const linkStyles = css`
   font-size: ${typography.size.s1}px;
   transition: all 150ms ease-out;
   color: ${color.mediumdark};
@@ -129,19 +128,12 @@ const Item = styled(({ active, loading, ...rest }) => <a {...rest} />)`
     `};
 `;
 
-export function ListItem({
-  loading,
-  left,
-  title,
-  center,
-  right,
-  active,
-  disabled,
-  href,
-  onClick,
-  LinkWrapper,
-  ...props
-}) {
+// eslint-disable-next-line jsx-a11y/anchor-has-content
+const Item = styled(({ active, loading, ...rest }) => <a {...rest} />)`
+  ${linkStyles}
+`;
+
+export function ListItem({ left, title, center, right, onClick, LinkWrapper, ...rest }) {
   const linkInner = (
     <ItemInner onClick={onClick} role="presentation">
       {left && <Left>{left}</Left>}
@@ -151,19 +143,17 @@ export function ListItem({
     </ItemInner>
   );
 
-  return (
-    <Item
-      as={LinkWrapper && href ? LinkWrapper : null}
-      href={!LinkWrapper ? href : undefined}
-      to={LinkWrapper ? href : undefined}
-      active={active}
-      loading={loading}
-      disabled={disabled}
-      {...props}
-    >
-      {linkInner}
-    </Item>
-  );
+  if (LinkWrapper) {
+    const StyledLinkWrapper = styled(({ active, loading, ...linkWrapperRest }) => (
+      <LinkWrapper {...linkWrapperRest} />
+    ))`
+      ${linkStyles};
+    `;
+
+    return <StyledLinkWrapper {...rest}>{linkInner}</StyledLinkWrapper>;
+  }
+
+  return <Item {...rest}>{linkInner}</Item>;
 }
 
 ListItem.propTypes = {
@@ -174,7 +164,6 @@ ListItem.propTypes = {
   right: PropTypes.node,
   active: PropTypes.bool,
   disabled: PropTypes.bool,
-  href: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   LinkWrapper: PropTypes.func,
   onClick: PropTypes.func,
 };
@@ -187,7 +176,6 @@ ListItem.defaultProps = {
   right: null,
   active: false,
   disabled: false,
-  href: null,
   LinkWrapper: undefined,
   onClick: undefined,
 };

--- a/src/components/tooltip/ListItem.stories.js
+++ b/src/components/tooltip/ListItem.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import { ListItem } from './ListItem';
 import { Icon } from '../Icon';
+import { StoryLinkWrapper } from '../StoryLinkWrapper';
 
 storiesOf('Design System|tooltip/ListItem', module)
   .addParameters({ component: ListItem })
@@ -54,4 +55,21 @@ storiesOf('Design System|tooltip/ListItem', module)
   ))
   .add('disabled', () => (
     <ListItem disabled left="left" title="disabled" center="center" right="right" />
+  ))
+  .add('with LinkWrapper', () => (
+    <>
+      <ListItem LinkWrapper={StoryLinkWrapper} loading href="http://www.google.com" />
+      <ListItem LinkWrapper={StoryLinkWrapper} title="Default" href="http://www.google.com" />
+      <ListItem
+        LinkWrapper={StoryLinkWrapper}
+        title="lorem ipsum dolor sit amet consectatur"
+        to="http://www.google.com"
+      />
+      <ListItem
+        LinkWrapper={StoryLinkWrapper}
+        title="Default icon"
+        right={<Icon icon="eye" />}
+        to="http://www.google.com"
+      />
+    </>
   ));

--- a/src/components/tooltip/TooltipLinkList.js
+++ b/src/components/tooltip/TooltipLinkList.js
@@ -10,16 +10,15 @@ const List = styled.div`
 export function TooltipLinkList({ links, LinkWrapper }) {
   return (
     <List>
-      {links.map(({ title, href, onClick, active, ...props }, index) => (
+      {links.map(({ title, onClick, active, ...rest }, index) => (
         <ListItem
           /* eslint-disable react/no-array-index-key */
           key={index}
           title={title}
           onClick={onClick}
           active={active}
-          href={href}
           LinkWrapper={LinkWrapper || null}
-          {...props}
+          {...rest}
         />
       ))}
     </List>
@@ -30,7 +29,6 @@ TooltipLinkList.propTypes = {
   links: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.node.isRequired,
-      href: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
       onClick: PropTypes.func,
       active: PropTypes.bool,
     }).isRequired


### PR DESCRIPTION
The `tooltip/ListItem` and `tooltip/TooltipLinkList` currently make a lot of assumptions about the prop name that contains the "href" for a link. This is fine for standard links which always use an href, but it complicates things when you also pass in a `LinkWrapper`. Gatsby links use the `to` prop whereas Next links use the `href` prop, so the code that we had:

```
href={!LinkWrapper ? href : undefined}
to={LinkWrapper ? href : undefined}
```


... is making too many assumptions about what every single `LinkWrapper` expects. I propose we leave those assumptions out and instead just pass the props down to the `LinkWrapper` so that this component can be more flexible. This means that whenever you use the `ListItem`, you have to be careful about what props you pass down, however that's the same concern you will have when you are mixing Next links and anchor tags anyway.