### PR TITLE
fix: Link - LinkWrapper optimisation

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -144,6 +144,17 @@ const LinkButton = styled.button`
   ${linkStyles};
 `;
 
+const applyStyle = LinkWrapper => {
+  return (
+    LinkWrapper &&
+    styled(({ containsIcon, inverse, nochrome, secondary, tertiary, ...linkWrapperRest }) => (
+      <LinkWrapper {...linkWrapperRest} />
+    ))`
+      ${linkStyles};
+    `
+  );
+};
+
 /**
  * Links can contains text and/or icons. Be careful using only icons, you must provide a text alternative via aria-label for accessibility.
  */
@@ -157,23 +168,16 @@ export function Link({ isButton, withArrow, LinkWrapper, children, ...rest }) {
     </Fragment>
   );
 
+  const StyledLinkWrapper = applyStyle(LinkWrapper);
+
+  let SelectedLink = LinkA;
   if (LinkWrapper) {
-    const StyledLinkWrapper = styled(
-      ({ containsIcon, inverse, nochrome, secondary, tertiary, ...linkWrapperRest }) => (
-        <LinkWrapper {...linkWrapperRest} />
-      )
-    )`
-      ${linkStyles};
-    `;
-
-    return <StyledLinkWrapper {...rest}>{content}</StyledLinkWrapper>;
+    SelectedLink = StyledLinkWrapper;
+  } else if (isButton) {
+    SelectedLink = LinkButton;
   }
 
-  if (isButton) {
-    return <LinkButton {...rest}>{content}</LinkButton>;
-  }
-
-  return <LinkA {...rest}>{content}</LinkA>;
+  return <SelectedLink {...rest}>{content}</SelectedLink>;
 }
 
 Link.propTypes = {

--- a/src/components/Link.stories.js
+++ b/src/components/Link.stories.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { Button } from './Button';
 import { Icon } from './Icon';
 import { Link } from './Link';
 import { StoryLinkWrapper } from './StoryLinkWrapper';
@@ -65,9 +64,5 @@ storiesOf('Design System|Link', module)
       <CustomLink tertiary LinkWrapper={StoryLinkWrapper} href="http://storybook.js.org">
         has a LinkWrapper like GatsbyLink or NextLink with custom styling
       </CustomLink>
-      <br />
-      <Link LinkWrapper={StoryLinkWrapper} href="http://storybook.js.org">
-        <Button>has a LinkWrapper like GatsbyLink or NextLink and a Button child</Button>
-      </Link>
     </div>
   ));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Link component accepts a `LinkWrapper` props. It is styled via styled-component, but it’s not exactly `LinkWrapper` that is passed, but a new component that omits a set of props.
But everytime `Link` renders, the styled `LinkWrapper` is created again, defining a new component. 

React considers it as a new component, the old button will be unmounted, and the new one will be mounted, at every render.

**What is the chosen solution to this problem?**
Memoize the styled `LinkWrapper` component.

Bonus: the weird `Link` story with a button as child is removed, inn favor of `Button` component with `ButtonWrapper`
