### PR TITLE
fix: ProgressDot accessibility

### DIFF
--- a/src/components/ProgressDots.js
+++ b/src/components/ProgressDots.js
@@ -49,7 +49,13 @@ export function ProgressDots({ loading, steps, progress, className, size }) {
     dots.push(<Dot loading={loading} active={i === progress - 1} key={i} size={size} />);
   }
   return (
-    <ProgressWrapper className={className} size={size}>
+    <ProgressWrapper
+      className={className}
+      size={size}
+      role="status"
+      aria-live="polite"
+      aria-label="Content is loading ..."
+    >
       {dots}
     </ProgressWrapper>
   );


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`ProgressDot` component is not accessible
* no text alternative.
* a loader should be a live region so SR announce any change after loading.

**What is the chosen solution to this problem?**
* set an `aria-label`
* discussed with @domyen, this component is an intermediate loading state.  Set aria-live to `polite` and role to `status`.
