### PR TITLE
fix: withTooltip accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "global": "^4.3.2",
+    "keycode": "^2.2.0",
     "polished": "^3.3.0",
     "prismjs": "1.13.0",
     "react-helmet": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-popper-tooltip": "^2.8.2",
     "recompose": "^0.30.0",
     "styled-components": "^4.1.2",
+    "uuid": "^3.3.2",
     "validatorjs": "^3.15.1"
   },
   "devDependencies": {

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -2,17 +2,22 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import TooltipTrigger from 'react-popper-tooltip';
+import uuid from 'uuid';
 
 import { Tooltip } from './Tooltip';
 
 // A target that doesn't speak popper
-const TargetContainer = styled.div`
+const ButtonContainer = styled.button`
+  background: transparent;
+  border: 0;
+  cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
   display: inline-block;
-  cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
-`;
-
-const TargetSvgContainer = styled.g`
-  cursor: ${props => (props.mode === 'hover' ? 'default' : 'pointer')};
+  font-size: inherit;
+  font-weight: inherit;
+  margin: 0;
+  padding: 0;
+  text-align: inherit;
+  text-decoration: none;
 `;
 
 const isDescendantOfAction = element => {
@@ -30,7 +35,6 @@ const isDescendantOfAction = element => {
 };
 
 function WithTooltip({
-  svg,
   trigger,
   closeOnClick,
   placement,
@@ -41,7 +45,7 @@ function WithTooltip({
   startOpen,
   ...props
 }) {
-  const Container = svg ? TargetSvgContainer : TargetContainer;
+  const id = React.useMemo(() => uuid.v4(), []);
   const [isTooltipShown, setTooltipShown] = useState(startOpen);
   const toggleTooltipShown = () => setTooltipShown(!isTooltipShown);
   const closeTooltip = () => setTooltipShown(false);
@@ -75,22 +79,31 @@ function WithTooltip({
           arrowProps={getArrowProps()}
           onClick={closeTooltipOnClick}
           {...getTooltipProps()}
+          id={id}
+          role="tooltip"
         >
           {typeof tooltip === 'function' ? tooltip({ onHide: closeTooltip }) : tooltip}
         </Tooltip>
       )}
     >
       {({ getTriggerProps, triggerRef }) => (
-        <Container ref={triggerRef} {...getTriggerProps()} {...props} onClick={toggleTooltipShown}>
+        <ButtonContainer
+          ref={triggerRef}
+          {...getTriggerProps()}
+          {...props}
+          onClick={toggleTooltipShown}
+          role="button"
+          aria-controls={id}
+          aria-describedby={isTooltipShown ? id : undefined}
+        >
           {children}
-        </Container>
+        </ButtonContainer>
       )}
     </TooltipTrigger>
   );
 }
 
 WithTooltip.propTypes = {
-  svg: PropTypes.bool,
   trigger: PropTypes.string,
   closeOnClick: PropTypes.bool,
   placement: PropTypes.string,
@@ -102,7 +115,6 @@ WithTooltip.propTypes = {
 };
 
 WithTooltip.defaultProps = {
-  svg: false,
   trigger: 'hover',
   closeOnClick: false,
   placement: 'top',

--- a/src/components/tooltip/WithTooltip.stories.js
+++ b/src/components/tooltip/WithTooltip.stories.js
@@ -66,8 +66,14 @@ storiesOf('Design System|tooltip/WithTooltip', module)
     </WithTooltip>
   ))
   .add('simple hover, as svg', () => (
-    <svg aria-label="Empty box to hover for tooltip">
-      <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />} as="g">
+    <svg>
+      <WithTooltip
+        placement="top"
+        trigger="hover"
+        tooltip={<Tooltip />}
+        as="g"
+        aria-label="Empty box to hover for tooltip"
+      >
         <Circle cx="150" cy="50" r="50" />
       </WithTooltip>
     </svg>
@@ -84,8 +90,14 @@ storiesOf('Design System|tooltip/WithTooltip', module)
   ))
 
   .add('simple click, as svg', () => (
-    <svg aria-label="Empty box to hover for tooltip">
-      <WithTooltip placement="top" trigger="click" tooltip={<Tooltip />} as="g">
+    <svg>
+      <WithTooltip
+        placement="top"
+        trigger="click"
+        tooltip={<Tooltip />}
+        as="g"
+        aria-label="Empty box to click for tooltip"
+      >
         <Circle cx="150" cy="50" r="50" />
       </WithTooltip>
     </svg>

--- a/src/components/tooltip/WithTooltip.stories.js
+++ b/src/components/tooltip/WithTooltip.stories.js
@@ -30,8 +30,8 @@ const Trigger = styled.div`
   color: white;
 `;
 
-const Rect = styled.rect`
-  fill: rgb(255, 255, 0);
+const Circle = styled.circle`
+  fill: fill: rgb(255, 0, 255);
 `;
 
 const Tooltip = ({ onHide }) => (
@@ -65,14 +65,12 @@ storiesOf('Design System|tooltip/WithTooltip', module)
       <Trigger>Hover me!</Trigger>
     </WithTooltip>
   ))
-  .add('simple hover, svg', () => (
-    <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />}>
-      <svg aria-label="Empty box to hover for tooltip">
-        <g>
-          <Rect x={0} y={0} width={200} height={200} />
-        </g>
-      </svg>
-    </WithTooltip>
+  .add('simple hover, as svg', () => (
+    <svg aria-label="Empty box to hover for tooltip">
+      <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />} as="g">
+        <Circle cx="150" cy="50" r="50" />
+      </WithTooltip>
+    </svg>
   ))
   .add('simple hover, functional', () => (
     <WithTooltip placement="top" trigger="hover" tooltip={Tooltip}>
@@ -83,6 +81,14 @@ storiesOf('Design System|tooltip/WithTooltip', module)
     <WithTooltip placement="top" trigger="click" tooltip={<Tooltip />}>
       <Trigger>Click me!</Trigger>
     </WithTooltip>
+  ))
+
+  .add('simple click, as svg', () => (
+    <svg aria-label="Empty box to hover for tooltip">
+      <WithTooltip placement="top" trigger="click" tooltip={<Tooltip />} as="g">
+        <Circle cx="150" cy="50" r="50" />
+      </WithTooltip>
+    </svg>
   ))
   .add('simple click start open', () => (
     <WithTooltip placement="top" trigger="click" startOpen tooltip={<Tooltip />}>

--- a/src/components/tooltip/WithTooltip.stories.js
+++ b/src/components/tooltip/WithTooltip.stories.js
@@ -30,6 +30,10 @@ const Trigger = styled.div`
   color: white;
 `;
 
+const Rect = styled.rect`
+  fill: rgb(255, 255, 0);
+`;
+
 const Tooltip = ({ onHide }) => (
   <TooltipMessage
     title="Lorem ipsum dolor sit"
@@ -52,7 +56,6 @@ storiesOf('Design System|tooltip/WithTooltip', module)
     <ViewPort>
       <BackgroundBox>
         <Spacer />
-        lol
         {storyFn()}
       </BackgroundBox>
     </ViewPort>
@@ -60,6 +63,15 @@ storiesOf('Design System|tooltip/WithTooltip', module)
   .add('simple hover', () => (
     <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />}>
       <Trigger>Hover me!</Trigger>
+    </WithTooltip>
+  ))
+  .add('simple hover, svg', () => (
+    <WithTooltip placement="top" trigger="hover" tooltip={<Tooltip />}>
+      <svg aria-label="Empty box to hover for tooltip">
+        <g>
+          <Rect x={0} y={0} width={200} height={200} />
+        </g>
+      </svg>
     </WithTooltip>
   ))
   .add('simple hover, functional', () => (

--- a/src/components/tooltip/WithTooltip.stories.js
+++ b/src/components/tooltip/WithTooltip.stories.js
@@ -52,6 +52,7 @@ storiesOf('Design System|tooltip/WithTooltip', module)
     <ViewPort>
       <BackgroundBox>
         <Spacer />
+        lol
         {storyFn()}
       </BackgroundBox>
     </ViewPort>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9907,7 +9907,8 @@ utils-merge@1.0.1:
 
 uuid@^3.3.2:
   version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 v8flags@^3.1.1:
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,6 +6066,11 @@ junk@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
 
+keycode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
+  integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
+
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`withTooltip` component is not accessible
1. no way to trigger the tooltip with keyboard because it’s a div
2. the tooltip is not identified as tooltips by assistive technologies
3. the tooltip is not associated with the trigger

**What is the chosen solution to this problem?**
1. semantic
* use button
* buttons are problematic for svg, where we want to have a tooltip on different zone, previously mapped on `<g>` tags. We introduced `as` props, suggested by @kylesuss. It render a particular component instead of the button, adding button keyboard behavior manually in that case, and the `role="button"`
```
<svg>
      <WithTooltip as="g" trigger="hover" tooltip={<Tooltip />} aria-label="Empty box to hover for tooltip">
          <Circle cx="150" cy="50" r="50" />
      </WithTooltip>
</svg>
```
* map the onMouseOver to onFocus
* map the onMouseOut to onBlur

2. add `role="tooltip"` on tooltip div

3. trigger button has an `aria-controls` attribute to indicate that it opens the identified element, and `aria-describedby` so SR will read the tooltip content on open.

**Bonus**
REMOVE TOGGLE
Having 2 ways to trigger the tooltip (mouse and keyboard) revealed a problem with the state management because it was a toggle. Take this scenario:
1. focus (keyboard): tooltip is shown
2. mouseover: it toggles, tooltip is hidden —> weird
3. blur (keyboard): it toggles, tooltip is shown —> weird

Instead of toggling the state value, we now really let TooltipTrigger component control it, by setting the `isTooltipShown` value.

MEMO
There are some function that are created at each render, creating a new reference everytime. Use React.memo to memoize them.