### PR TITLE
Memoize LinkWrapper in tooltip/ListItem for perf

### DIFF
--- a/src/components/tooltip/ListItem.js
+++ b/src/components/tooltip/ListItem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { color, typography } from '../shared/styles';
@@ -133,6 +133,12 @@ const Item = styled(({ active, activeColor, loading, ...rest }) => <a {...rest} 
   ${linkStyles}
 `;
 
+const buildStyledLinkWrapper = LinkWrapper => styled(
+  ({ active, loading, activeColor, ...linkWrapperRest }) => <LinkWrapper {...linkWrapperRest} />
+)`
+  ${linkStyles}
+`;
+
 export function ListItem({
   appearance,
   left,
@@ -154,11 +160,7 @@ export function ListItem({
   );
 
   if (LinkWrapper) {
-    const StyledLinkWrapper = styled(({ active, loading, activeColor, ...linkWrapperRest }) => (
-      <LinkWrapper {...linkWrapperRest} />
-    ))`
-      ${linkStyles};
-    `;
+    const StyledLinkWrapper = useMemo(() => buildStyledLinkWrapper(LinkWrapper), [LinkWrapper]);
 
     return (
       <StyledLinkWrapper activeColor={listItemActiveColor} {...rest}>


### PR DESCRIPTION
This has come up a few times in @jsomsanith 's PRs, but we should avoid creating these styled components in the render function as it can create a perf issue. I think this is the last one we need to update.