### PR TITLE
Remove Tooltip onClick duplication

### DIFF
--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -81,7 +81,7 @@ function WithTooltip({
       )}
     >
       {({ getTriggerProps, triggerRef }) => (
-        <Container ref={triggerRef} {...getTriggerProps()} {...props} onClick={toggleTooltipShown}>
+        <Container ref={triggerRef} {...getTriggerProps()} {...props}>
           {children}
         </Container>
       )}


### PR DESCRIPTION
`toggleTooltipShown` was being called twice as we were manually passing an `onClick` to the tooltip trigger and the `react-popper-tooltip` library was also calling the toggle function as a result of the `onVisibilityChange`  prop.


I just remove our manual `onClick` handler and it appears to be unnecessary.

Closes #51