### PR TITLE
Change Input appearance="pill" focus color to blue

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -99,7 +99,7 @@ const InputWrapper = styled.div`
 
       box-shadow: ${color.medium} 0 0 0 1px inset;
 
-      &:focus { box-shadow: ${color.primary} 0 0 0 1px inset; }
+      &:focus { box-shadow: ${color.secondary} 0 0 0 1px inset; }
     `}
 
     ${props => props.appearance === 'code' && css`


### PR DESCRIPTION
Changed the focus color of `Input` `appareance="pill"` from pink (`primary`) to blue (`secondary`). No other functional changes.

New focus color is: 
![image](https://user-images.githubusercontent.com/263385/60540689-c185fd00-9cdd-11e9-874a-e44633ce7bfd.png)
