### PR TITLE
fix: Spinner accessibility

### DIFF
--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -91,5 +91,12 @@ const SpinnerWrapper = styled.div`
 `;
 
 export function Spinner({ ...props }) {
-  return <SpinnerWrapper {...props} />;
+  return (
+    <SpinnerWrapper
+      aria-label="Content is loading ..."
+      aria-live="polite"
+      role="status"
+      {...props}
+    />
+  );
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Spinner` component is not accessible, this PR fixes the same issues as ProgressDot (#45)
* no text alternative.
* a loader should be a live region so SR announce any change after loading.

**What is the chosen solution to this problem?**
* set an `aria-label`.
* this component is used to load subparts of the page. It should not be an assertive region or it can be a hell for screen readers. Set aria-live to `polite` and role to `status`.