### PR TITLE
Ignore stories in compiled output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel src -d dist",
+    "build": "babel src -d dist --ignore **/*.stories.js",
     "build-docs": "build-storybook --docs",
     "build-storybook": "build-storybook",
     "chromatic": "CHROMATIC_APP_CODE=9ofhn0iql7n chromatic test",

--- a/src/test.js
+++ b/src/test.js
@@ -1,7 +1,0 @@
-import ExampleComponent from './index';
-
-describe('ExampleComponent', () => {
-  it('is truthy', () => {
-    expect(ExampleComponent).toBeTruthy();
-  });
-});


### PR DESCRIPTION
### Overview

When compiling the design system for distribution via Babel, we can ignore bundling the `stories.js` files. 

I also deleted a test that didn't appear to be doing anything, but I can add that back if I'm wrong.

### Result
![image](https://user-images.githubusercontent.com/9113740/62586612-eee93c00-b883-11e9-862a-f990c63935ec.png)
