### PR TITLE
Revert "Ignore stories in compiled output."

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "dist/index.js",
   "scripts": {
-    "build": "babel src -d dist --ignore **/*.stories.js",
+    "build": "babel src -d dist",
     "build-docs": "build-storybook --docs",
     "build-storybook": "build-storybook",
     "chromatic": "CHROMATIC_APP_CODE=9ofhn0iql7n chromatic test",

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,7 @@
+import ExampleComponent from './index';
+
+describe('ExampleComponent', () => {
+  it('is truthy', () => {
+    expect(ExampleComponent).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Breaks the ability for consumer Storybooks to browse the design system alongside their components which is an important feature for SDS adoption.