### PR TITLE
Move remaining body styles to `bodyStyles`

### DIFF
--- a/src/components/shared/global.js
+++ b/src/components/shared/global.js
@@ -6,6 +6,10 @@ export const bodyStyles = css`
   font-size: ${typography.size.s3}px;
   color: ${color.darkest};
 
+  margin: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -116,9 +120,5 @@ export const GlobalStyle = createGlobalStyle`
 
   body {
     ${bodyStyles}
-
-    margin: 0;
-    overflow-y: auto;
-    overflow-x: hidden;
   }
 `;


### PR DESCRIPTION
This isn't a complete fix for #54, but it is a step forward, as it allows users to safely do:

```js
import { createGlobalStyle } from 'styled-components';
import { global } from '@storybook/design-system';

const CustomGlobalStyle = createGlobalStyle`
   body {
     ${global.bodyStyles}
   }
}`
```

In their own code to avoid the `@import`.