### PR TITLE
Remove font import from GlobalStyle, export fontHref

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
+import { fontHref } from '../src/components/shared/global';
 import 'storybook-chromatic';
 
 import { GlobalStyle } from '../src/components/shared/global';
@@ -21,3 +22,16 @@ configure(
   ],
   module
 );
+
+// Load the font and avoid re-loading it when components change
+const fontLinkId = 'font-link';
+
+if (!document.getElementById(fontLinkId)) {
+  const fontLink = document.createElement('link');
+
+  fontLink.id = fontLinkId;
+  fontLink.href = fontHref;
+  fontLink.rel = 'stylesheet';
+
+  document.head.appendChild(fontLink);
+}

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
-import { fontHref } from '../src/components/shared/global';
+import { fontUrl } from '../src/components/shared/global';
 import 'storybook-chromatic';
 
 import { GlobalStyle } from '../src/components/shared/global';
@@ -30,7 +30,7 @@ if (!document.getElementById(fontLinkId)) {
   const fontLink = document.createElement('link');
 
   fontLink.id = fontLinkId;
-  fontLink.href = fontHref;
+  fontLink.href = fontUrl;
   fontLink.rel = 'stylesheet';
 
   document.head.appendChild(fontLink);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
-import { fontUrl } from '../src/components/shared/global';
+import { loadFontsForStorybook } from '../src/utils/index';
 import 'storybook-chromatic';
 
 import { GlobalStyle } from '../src/components/shared/global';
@@ -23,15 +23,4 @@ configure(
   module
 );
 
-// Load the font and avoid re-loading it when components change
-const fontLinkId = 'font-link';
-
-if (!document.getElementById(fontLinkId)) {
-  const fontLink = document.createElement('link');
-
-  fontLink.id = fontLinkId;
-  fontLink.href = fontUrl;
-  fontLink.rel = 'stylesheet';
-
-  document.head.appendChild(fontLink);
-}
+loadFontsForStorybook();

--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ class Example extends Component {
 }
 ```
 
+## Font Loading
+
+Rather than `@import` fonts in the `GlobalStyle` component, the design system's font URL is exported with the intention of using it in a `<link>` tag as the href. Different frameworks and environments handle component re-renders in their own way (a re-render would cause the font to be re-fetched), so this approach allows the design system consumers to choose the font loading method that is most appropriate for their environment.
+
+#### Option 1: Build the link tag manually
+
+```javascript
+import { global } from '@storybook/design-system';
+
+const fontLink = document.createElement('link');
+
+fontLink.href = global.fontUrl;
+fontLink.rel = 'stylesheet';
+
+document.head.appendChild(fontLink);
+```
+
+#### Option 2: Render the link tag in a component
+
+```jsx
+import React from 'react';
+import { global } from '@storybook/design-system';
+
+const Layout = ({ children }) => (
+  <html>
+    <head>
+      <link href={global.fontUrl} rel="stylesheet" />
+    </head>
+
+    <body>{children}</body>
+  </html>
+);
+
+export default Layout;
+```
+
 ## Development Scripts
 
 #### `yarn release`

--- a/src/components/shared/global.js
+++ b/src/components/shared/global.js
@@ -115,12 +115,8 @@ export const bodyStyles = css`
   }
 `;
 
-// Rather than @import the font in the GlobalStyle below, the font URL is
-// exported  with the intention of using it in a <link> tag as the href.
-// Different frameworks and environments handle component re-renders in their
-// own way (a re-render would case the font to be re-fetched), so this approach
-//  allows the design system consumers to choose the font loading method
-// that is most appropriate for their environment.
+// Allow design system consumers to access font settings but control how and
+// where they load the font.
 export const fontUrl =
   'https://fonts.googleapis.com/css?family=Nunito+Sans:400,700,800,900&display=swap';
 

--- a/src/components/shared/global.js
+++ b/src/components/shared/global.js
@@ -115,9 +115,10 @@ export const bodyStyles = css`
   }
 `;
 
-export const GlobalStyle = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css?family=Nunito+Sans:400,700,800,900');
+export const fontHref =
+  'https://fonts.googleapis.com/css?family=Nunito+Sans:400,700,800,900&display=swap';
 
+export const GlobalStyle = createGlobalStyle`
   body {
     ${bodyStyles}
   }

--- a/src/components/shared/global.js
+++ b/src/components/shared/global.js
@@ -115,7 +115,13 @@ export const bodyStyles = css`
   }
 `;
 
-export const fontHref =
+// Rather than @import the font in the GlobalStyle below, the font URL is
+// exported  with the intention of using it in a <link> tag as the href.
+// Different frameworks and environments handle component re-renders in their
+// own way (a re-render would case the font to be re-fetched), so this approach
+//  allows the design system consumers to choose the font loading method
+// that is most appropriate for their environment.
+export const fontUrl =
   'https://fonts.googleapis.com/css?family=Nunito+Sans:400,700,800,900&display=swap';
 
 export const GlobalStyle = createGlobalStyle`

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './utils';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export * from './loadFontsForStorybook';

--- a/src/utils/loadFontsForStorybook.js
+++ b/src/utils/loadFontsForStorybook.js
@@ -1,0 +1,17 @@
+/* eslint-env browser */
+import { fontUrl } from '../components/shared/global';
+
+// Load the font and avoid re-loading it when components change
+const fontLinkId = 'storybook-font-link-tag';
+
+export const loadFontsForStorybook = () => {
+  if (!document.getElementById(fontLinkId)) {
+    const fontLink = document.createElement('link');
+
+    fontLink.id = fontLinkId;
+    fontLink.href = fontUrl;
+    fontLink.rel = 'stylesheet';
+
+    document.head.appendChild(fontLink);
+  }
+};


### PR DESCRIPTION
Let's just leave the font import out of the GlobalStyle and export the fontHref so that the design system consumers can share font settings, but load them in the most appropriate way for their environment.

Closes #54 