### PR TITLE
Add delayHide prop to tooltip for better hover behavior

### DIFF
--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -95,6 +95,7 @@ function WithTooltip({
   tooltip,
   children,
   startOpen,
+  delayHide,
   ...props
 }) {
   const id = React.useMemo(() => uuid.v4(), []);
@@ -112,6 +113,7 @@ function WithTooltip({
 
   return (
     <TooltipTrigger
+      delayHide={delayHide}
       placement={placement}
       trigger={trigger}
       tooltipShown={isTooltipShown}
@@ -165,6 +167,7 @@ WithTooltip.propTypes = {
   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   children: PropTypes.node.isRequired,
   startOpen: PropTypes.bool,
+  delayHide: PropTypes.number,
 };
 
 WithTooltip.defaultProps = {
@@ -175,6 +178,7 @@ WithTooltip.defaultProps = {
   modifiers: {},
   hasChrome: true,
   startOpen: false,
+  delayHide: 100,
 };
 
 export default WithTooltip;


### PR DESCRIPTION
Thanks for the idea @domyen . Def seemed to do the trick.

Before:
![tooltip-before](https://user-images.githubusercontent.com/3035355/66328787-8bfb3c00-e8ea-11e9-992c-7d03a436ae0b.gif)

After:
![tooltip-after](https://user-images.githubusercontent.com/3035355/66328796-90bff000-e8ea-11e9-98db-4395b543813e.gif)

Closes #82 