### PR TITLE
Fix Highlight PropType error for CSS langauge

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -7,7 +7,7 @@ import loadLanguages from 'prismjs/components/index';
 import PropTypes from 'prop-types';
 import { color, typography } from './shared/styles';
 
-const languages = ['bash', 'javascript', 'typescript', 'json'];
+const languages = ['bash', 'javascript', 'typescript', 'json', 'css'];
 loadLanguages(languages);
 
 // Prism theme copied from 'prismjs/themes/prism.css.' -- without Webpack, the CSS


### PR DESCRIPTION
Was getting a PropType error for this. Missed one of the languages in the Highlight component refactor.