### PR TITLE
Remove default styling for Highlight code, pre selectors, conflict with globals

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Prism from 'prismjs';
 import loadLanguages from 'prismjs/components/index';
 import PropTypes from 'prop-types';
-import { color, typography } from './shared/styles';
+import { color } from './shared/styles';
 
 const languages = ['bash', 'javascript', 'typescript', 'json', 'css'];
 loadLanguages(languages);
@@ -18,12 +18,13 @@ loadLanguages(languages);
 const HighlightBlock = styled.div`
   /*
     Line below from: prismjs/themes/prism.css, with removal of overly specific
-    selectors (primarily [class*=language-]) so they are easier to override.
+    selectors (primarily [class*=language-]) and selectors that collide with our
+    global styling (primarly code & pre selectors).
   */
-  code,pre{color:#000;background:0 0;text-shadow:0 1px #fff;font-family:Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;text-align:left;white-space:pre;word-spacing:normal;word-break:normal;word-wrap:normal;line-height:1.5;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}code ::-moz-selection,code::-moz-selection,pre ::-moz-selection,pre::-moz-selection{text-shadow:none;background:#b3d4fc}code ::selection,code::selection,pre ::selection,pre::selection{text-shadow:none;background:#b3d4fc}@media print{code,pre{text-shadow:none}}pre{padding:1em;margin:.5em 0;overflow:auto}:not(pre)>code,pre{background:#f5f2f0}:not(pre)>code{padding:.1em;border-radius:.3em;white-space:normal}.token.cdata,.token.comment,.token.doctype,.token.prolog{color:#708090}.token.punctuation{color:#999}.namespace{opacity:.7}.token.boolean,.token.constant,.token.deleted,.token.number,.token.property,.token.symbol,.token.tag{color:#905}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#690}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url{color:#a67f59;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.class-name,.token.function{color:#dd4a68}.token.important,.token.regex,.token.variable{color:#e90}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
+  .token.cdata,.token.comment,.token.doctype,.token.prolog{color:#708090}.token.punctuation{color:#999}.namespace{opacity:.7}.token.boolean,.token.constant,.token.deleted,.token.number,.token.property,.token.symbol,.token.tag{color:#905}.token.attr-name,.token.builtin,.token.char,.token.inserted,.token.selector,.token.string{color:#690}.language-css .token.string,.style .token.string,.token.entity,.token.operator,.token.url{color:#a67f59;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.class-name,.token.function{color:#dd4a68}.token.important,.token.regex,.token.variable{color:#e90}.token.bold,.token.important{font-weight:700}.token.italic{font-style:italic}.token.entity{cursor:help}
 
   code, pre {
-    font-family: ${typography.type.code};
+    color: ${color.darkest};
   }
 
   code {
@@ -34,6 +35,12 @@ const HighlightBlock = styled.div`
     padding: 11px 1rem;
     margin: 1rem 0;
     background: ${color.lighter};
+  }
+
+  .language-bash .token.operator,
+  .language-bash .token.function {
+    color: ${color.darkest};
+    background: none;
   }
 `;
 


### PR DESCRIPTION
After a bit of debugging, I realize that the "theme" I brought over for prism js was overriding a bunch of our global styles for code & pre elements in `Highlight` blocks. I think it is best to just remove those styles and instead default to our own global styling. I have left the theme styles for prism that target highlighted elements of the code.