### PR TITLE
Add left, right padding back to Highlight component

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -27,10 +27,6 @@ const HighlightBlock = styled.div`
     color: ${color.darkest};
   }
 
-  code {
-    padding: 0;
-  }
-
   pre {
     padding: 11px 1rem;
     margin: 1rem 0;


### PR DESCRIPTION
Looks like the consumers are actually utilizing the global padding on the `code` blocks.