### PR TITLE
Add story names to preserve component history

### DIFF
--- a/src/components/Avatar.stories.js
+++ b/src/components/Avatar.stories.js
@@ -22,6 +22,10 @@ export const large = () => (
   </div>
 );
 
+large.story = {
+  name: 'large',
+};
+
 export const medium = () => (
   <div>
     <Avatar loading />
@@ -29,6 +33,10 @@ export const medium = () => (
     <Avatar username="Tom Coleman" src="https://avatars2.githubusercontent.com/u/132554" />
   </div>
 );
+
+medium.story = {
+  name: 'medium',
+};
 
 export const small = () => (
   <div>
@@ -42,6 +50,10 @@ export const small = () => (
   </div>
 );
 
+small.story = {
+  name: 'small',
+};
+
 export const tiny = () => (
   <div>
     <Avatar loading size="tiny" />
@@ -53,3 +65,7 @@ export const tiny = () => (
     />
   </div>
 );
+
+tiny.story = {
+  name: 'tiny',
+};

--- a/src/components/AvatarList.stories.js
+++ b/src/components/AvatarList.stories.js
@@ -32,7 +32,17 @@ export default {
 };
 
 export const short = () => <AvatarList users={users.slice(0, 2)} />;
+
+short.story = {
+  name: 'short',
+};
+
 export const ellipsized = () => <AvatarList users={users} />;
+
+ellipsized.story = {
+  name: 'ellipsized',
+};
+
 export const bigUserCount = () => <AvatarList users={users} userCount={100} />;
 
 bigUserCount.story = {
@@ -46,4 +56,13 @@ smallSize.story = {
 };
 
 export const loading = () => <AvatarList loading />;
+
+loading.story = {
+  name: 'loading',
+};
+
 export const empty = () => <AvatarList users={[]} />;
+
+empty.story = {
+  name: 'empty',
+};

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -17,6 +17,10 @@ export const all = () => (
   </div>
 );
 
+all.story = {
+  name: 'all',
+};
+
 export const withIcon = () => (
   <Badge status="warning">
     <Icon icon="check" inline />

--- a/src/components/Button.stories.js
+++ b/src/components/Button.stories.js
@@ -34,6 +34,10 @@ export const buttons = () => (
   </>
 );
 
+buttons.story = {
+  name: 'buttons',
+};
+
 export const sizes = () => (
   <>
     <Button appearance="primary">Default</Button>
@@ -42,6 +46,10 @@ export const sizes = () => (
     </Button>
   </>
 );
+
+sizes.story = {
+  name: 'sizes',
+};
 
 export const loading = () => (
   <>
@@ -63,6 +71,10 @@ export const loading = () => (
   </>
 );
 
+loading.story = {
+  name: 'loading',
+};
+
 export const disabled = () => (
   <>
     <Button appearance="primary" isDisabled>
@@ -80,6 +92,10 @@ export const disabled = () => (
   </>
 );
 
+disabled.story = {
+  name: 'disabled',
+};
+
 export const containsIcon = () => (
   <>
     <Button appearance="outline" containsIcon>
@@ -90,6 +106,10 @@ export const containsIcon = () => (
     </Button>
   </>
 );
+
+containsIcon.story = {
+  name: 'containsIcon',
+};
 
 export const buttonWrapper = () => (
   <div>

--- a/src/components/Checkbox.stories.js
+++ b/src/components/Checkbox.stories.js
@@ -40,6 +40,14 @@ export const unchecked = () => (
   <Checkbox id="Unchecked" label="Cats" hideLabel onChange={onChange} />
 );
 
+unchecked.story = {
+  name: 'unchecked',
+};
+
 export const checked = () => (
   <Checkbox id="Checked" label="Cats" hideLabel checked onChange={onChange} />
 );
+
+checked.story = {
+  name: 'checked',
+};

--- a/src/components/Highlight.stories.js
+++ b/src/components/Highlight.stories.js
@@ -86,6 +86,10 @@ export const bash = () => (
   </>
 );
 
+bash.story = {
+  name: 'bash',
+};
+
 export const javascript = () => (
   <>
     <strong>Autoformat</strong>
@@ -94,6 +98,10 @@ export const javascript = () => (
     <Highlight>{javascriptCodeWithWrappers}</Highlight>
   </>
 );
+
+javascript.story = {
+  name: 'javascript',
+};
 
 export const typescript = () => (
   <>
@@ -104,6 +112,10 @@ export const typescript = () => (
   </>
 );
 
+typescript.story = {
+  name: 'typescript',
+};
+
 export const css = () => (
   <>
     <strong>Autoformat</strong>
@@ -113,6 +125,10 @@ export const css = () => (
   </>
 );
 
+css.story = {
+  name: 'css',
+};
+
 export const json = () => (
   <>
     <strong>Autoformat</strong>
@@ -121,6 +137,10 @@ export const json = () => (
     <Highlight>{jsonCodeWithWrappers}</Highlight>
   </>
 );
+
+json.story = {
+  name: 'json',
+};
 
 const SmallContainer = styled.div`
   max-width: 300px;
@@ -132,6 +152,10 @@ export const wrapping = () => (
   </SmallContainer>
 );
 
+wrapping.story = {
+  name: 'wrapping',
+};
+
 const StyledHighlight = styled(Highlight)`
   code,
   pre {
@@ -140,3 +164,7 @@ const StyledHighlight = styled(Highlight)`
 `;
 
 export const customStyling = () => <StyledHighlight language="json">{jsonCode}</StyledHighlight>;
+
+customStyling.story = {
+  name: 'customStyling',
+};

--- a/src/components/Icon.stories.js
+++ b/src/components/Icon.stories.js
@@ -67,6 +67,10 @@ export const labels = () => (
   </Fragment>
 );
 
+labels.story = {
+  name: 'labels',
+};
+
 export const noLabels = () => (
   <List>
     {Object.keys(icons).map(key => (
@@ -77,14 +81,26 @@ export const noLabels = () => (
   </List>
 );
 
+noLabels.story = {
+  name: 'noLabels',
+};
+
 export const inline = () => (
   <Fragment>
     this is an inline <Icon icon="facehappy" aria-label="Happy face" /> icon (default)
   </Fragment>
 );
 
+inline.story = {
+  name: 'inline',
+};
+
 export const block = () => (
   <Fragment>
     this is a block <Icon icon="facehappy" aria-label="Happy face" block /> icon
   </Fragment>
 );
+
+block.story = {
+  name: 'block',
+};

--- a/src/components/Input.stories.js
+++ b/src/components/Input.stories.js
@@ -183,6 +183,10 @@ export const secondary = () => (
   </form>
 );
 
+secondary.story = {
+  name: 'secondary',
+};
+
 export const tertiary = () => (
   <form style={{ background: '#EEEEEE', padding: '3em' }}>
     <Input
@@ -231,6 +235,10 @@ export const tertiary = () => (
   </form>
 );
 
+tertiary.story = {
+  name: 'tertiary',
+};
+
 export const pill = () => (
   <Input
     id="Pill"
@@ -242,6 +250,10 @@ export const pill = () => (
     onChange={onChange}
   />
 );
+
+pill.story = {
+  name: 'pill',
+};
 
 export const code = () => (
   <form style={{ background: '#EEEEEE', padding: '3em' }}>
@@ -274,3 +286,7 @@ export const code = () => (
     />
   </form>
 );
+
+code.story = {
+  name: 'code',
+};

--- a/src/components/Link.stories.js
+++ b/src/components/Link.stories.js
@@ -39,17 +39,29 @@ export const all = () => (
   </>
 );
 
+all.story = {
+  name: 'all',
+};
+
 export const withArrow = () => (
   <Link containsIcon withArrow href="https://learnstorybook.com">
     withArrow shows an arrow behind the link
   </Link>
 );
 
+withArrow.story = {
+  name: 'withArrow',
+};
+
 export const containsIcon = () => (
   <Link containsIcon href="https://learnstorybook.com" aria-label="Toggle side bar">
     <Icon icon="sidebar" aria-hidden />
   </Link>
 );
+
+containsIcon.story = {
+  name: 'containsIcon',
+};
 
 export const icon = () => (
   <Link href="https://learnstorybook.com">
@@ -58,12 +70,20 @@ export const icon = () => (
   </Link>
 );
 
+icon.story = {
+  name: 'icon',
+};
+
 export const isButton = () => (
   /* eslint-disable-next-line */
   <Link isButton onClick={onLinkClick}>
     is actually a button
   </Link>
 );
+
+isButton.story = {
+  name: 'isButton',
+};
 
 export const hasLinkWrapper = () => (
   <>
@@ -77,3 +97,7 @@ export const hasLinkWrapper = () => (
     </CustomLink>
   </>
 );
+
+hasLinkWrapper.story = {
+  name: 'hasLinkWrapper',
+};

--- a/src/components/ProgressDots.stories.js
+++ b/src/components/ProgressDots.stories.js
@@ -8,9 +8,29 @@ export default {
 };
 
 export const loading = () => <ProgressDots loading />;
+
+loading.story = {
+  name: 'loading',
+};
+
 export const starting = () => <ProgressDots steps={4} progress={1} />;
+
+starting.story = {
+  name: 'starting',
+};
+
 export const halfway = () => <ProgressDots steps={4} progress={2} />;
+
+halfway.story = {
+  name: 'halfway',
+};
+
 export const complete = () => <ProgressDots steps={4} progress={4} />;
+
+complete.story = {
+  name: 'complete',
+};
+
 export const largeComplete = () => <ProgressDots steps={4} progress={4} size="large" />;
 
 largeComplete.story = {

--- a/src/components/Radio.stories.js
+++ b/src/components/Radio.stories.js
@@ -29,6 +29,14 @@ export const unchecked = () => (
   <Radio id="Mice" label="Mice" hideLabel value="mice" onChange={onChange} />
 );
 
+unchecked.story = {
+  name: 'unchecked',
+};
+
 export const checked = () => (
   <Radio id="Dogs" label="Dogs" hideLabel value="dogs" checked onChange={onChange} />
 );
+
+checked.story = {
+  name: 'checked',
+};

--- a/src/components/Select.stories.js
+++ b/src/components/Select.stories.js
@@ -193,6 +193,10 @@ export const secondary = () => (
   </form>
 );
 
+secondary.story = {
+  name: 'secondary',
+};
+
 export const tertiary = () => (
   <form style={{ background: '#EEEEEE', padding: '3em' }}>
     <Select
@@ -216,3 +220,7 @@ export const tertiary = () => (
     />
   </form>
 );
+
+tertiary.story = {
+  name: 'tertiary',
+};

--- a/src/components/Spinner.stories.js
+++ b/src/components/Spinner.stories.js
@@ -32,8 +32,16 @@ export const inForm = () => (
   </div>
 );
 
+inForm.story = {
+  name: 'inForm',
+};
+
 export const inline = () => (
   <div style={{ background: '#eee', padding: '1.5em', position: 'relative' }}>
     <Spinner inline />
   </div>
 );
+
+inline.story = {
+  name: 'inline',
+};

--- a/src/components/Subheading.stories.js
+++ b/src/components/Subheading.stories.js
@@ -7,3 +7,7 @@ export default {
 };
 
 export const subheading = () => <Subheading>Subheading</Subheading>;
+
+subheading.story = {
+  name: 'subheading',
+};

--- a/src/components/Textarea.stories.js
+++ b/src/components/Textarea.stories.js
@@ -158,6 +158,10 @@ export const secondary = () => (
   </form>
 );
 
+secondary.story = {
+  name: 'secondary',
+};
+
 export const tertiary = () => (
   <form style={{ background: '#EEEEEE', padding: '3em' }}>
     <Textarea
@@ -215,6 +219,10 @@ export const tertiary = () => (
     />
   </form>
 );
+
+tertiary.story = {
+  name: 'tertiary',
+};
 
 export const code = () => (
   <form style={{ background: '#EEEEEE', padding: '3em' }}>
@@ -282,3 +290,7 @@ export const code = () => (
     />
   </form>
 );
+
+code.story = {
+  name: 'code',
+};

--- a/src/components/tooltip/ListItem.stories.js
+++ b/src/components/tooltip/ListItem.stories.js
@@ -46,7 +46,16 @@ export const all = () => (
   </div>
 );
 
+all.story = {
+  name: 'all',
+};
+
 export const loading = () => <ListItem loading />;
+
+loading.story = {
+  name: 'loading',
+};
+
 export const defaultStory = () => <ListItem title="Default" />;
 
 defaultStory.story = {
@@ -104,6 +113,10 @@ wPositionsActiveLongTitle.story = {
 export const disabled = () => (
   <ListItem disabled left="left" title="disabled" center="center" right="right" />
 );
+
+disabled.story = {
+  name: 'disabled',
+};
 
 export const withLinkWrapper = () => (
   <>


### PR DESCRIPTION
I noticed in #95 that a large number of the stories had different names -- they were capitalized and spaces were added. As it turns out, Storybook uses `startCase` when you use CSF. We missed out on that originally as we were on a prerelease. I think I'd like to preserve the component history on Chromatic & therefore would opt to define the story names manually for now.

@leerob I am hoping to merge this into your `typography-and-colors` branch so that we can have Chromatic run again and only isolate the changes from your effort in there.