### PR TITLE
Add yaml syntax highlighting to Highlight component

### DIFF
--- a/src/components/Highlight.js
+++ b/src/components/Highlight.js
@@ -7,7 +7,7 @@ import loadLanguages from 'prismjs/components/index';
 import PropTypes from 'prop-types';
 import { color } from './shared/styles';
 
-const languages = ['bash', 'javascript', 'typescript', 'json', 'css'];
+const languages = ['bash', 'javascript', 'typescript', 'json', 'css', 'yaml'];
 loadLanguages(languages);
 
 // Prism theme copied from 'prismjs/themes/prism.css.' -- without Webpack, the CSS

--- a/src/components/Highlight.stories.js
+++ b/src/components/Highlight.stories.js
@@ -56,6 +56,20 @@ const jsonCode = `{
 
 const jsonCodeWithWrappers = `<pre class="language-json"><code class="language-json">${jsonCode}</code></pre>`;
 
+const yamlCode = `version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.10.0
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+`;
+
+const yamlCodeWithWrappers = `<pre class="language-yaml"><code class="language-yaml">${yamlCode}</code></pre>`;
+
 export default {
   title: 'Design System|Highlight',
   component: Highlight,
@@ -69,6 +83,7 @@ export const allLanguages = () => (
       typescriptCodeWithWrappers,
       cssCodeWithWrappers,
       jsonCodeWithWrappers,
+      yamlCodeWithWrappers,
     ].join('')}
   </Highlight>
 );
@@ -119,6 +134,15 @@ export const json = () => (
     <Highlight language="json">{jsonCode}</Highlight>
     <strong>Pre-formatted</strong>
     <Highlight>{jsonCodeWithWrappers}</Highlight>
+  </>
+);
+
+export const yaml = () => (
+  <>
+    <strong>Autoformat</strong>
+    <Highlight language="yaml">{yamlCode}</Highlight>
+    <strong>Pre-formatted</strong>
+    <Highlight>{yamlCodeWithWrappers}</Highlight>
   </>
 );
 


### PR DESCRIPTION
Want to get this synced over to learnstorybook.com since we show yaml files over there.

Closes #93 