### PR TITLE
Fix react version, only bundle 1. Yarn matcher not working as expected.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "lint-staged": "^9.4.2",
     "prettier": "^1.18.2",
     "prettier-eslint": "^9.0.0",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
     "sort-package-json": "^1.21.0",
     "storybook-chromatic": "^3.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9718,7 +9718,7 @@ react-docgen@^4.1.0:
     node-dir "^0.1.10"
     recast "^0.17.3"
 
-react-dom@^16.10.2, react-dom@^16.8.3:
+react-dom@^16.8.3:
   version "16.10.2"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.10.2.tgz#4840bce5409176bc3a1f2bd8cb10b92db452fda6"
   integrity sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==
@@ -9895,7 +9895,7 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^16.10.2, react@^16.8.3:
+react@^16.8.3:
   version "16.10.2"
   resolved "https://registry.npmjs.org/react/-/react-16.10.2.tgz#a5ede5cdd5c536f745173c8da47bda64797a4cf0"
   integrity sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==


### PR DESCRIPTION
Follow up to #98 -- there were 2 versions of React being loaded as a result. Need to troubleshoot why that happened as the version matchers seemed right, but for now, this will fix.