### PR TITLE
Make border-radius more consistent

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { color, typography } from './shared/styles';
+import { color, typography, spacing } from './shared/styles';
 import { jiggle } from './shared/animation';
 import { Icon } from './Icon';
 
@@ -137,7 +137,7 @@ const InputWrapper = styled.div`
       top: -4px;
       right: auto;
       left: 0;
-      border-radius: 4px;
+      border-radius: ${spacing.borderRadius.small}px;
       padding: 6px;
     `}
   }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { color, typography } from './shared/styles';
+import { color, typography, spacing } from './shared/styles';
 import { jiggle } from './shared/animation';
 import { Icon } from './Icon';
 import { Spinner } from './Spinner';
@@ -110,7 +110,7 @@ const SelectWrapper = styled.span`
 		position: absolute;
 		z-index: 1;
 		pointer-events: none;
-    border-radius: 4px;
+    border-radius: ${spacing.borderRadius.small}px;
 	}
 
   ${Arrow} {

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { typography } from '../shared/styles';
+import { typography, spacing } from '../shared/styles';
 
 const ifPlacementEquals = (placement, value, fallback = 0) => props =>
   props['data-placement'].split('-')[0] === placement ? value : fallback;
@@ -64,7 +64,7 @@ const TooltipWrapper = styled.div`
         rgba(255, 255, 255, 0.97) 100%
       );
       filter: drop-shadow(0px 5px 5px rgba(0, 0, 0, 0.05)) drop-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
-      border-radius: 4px;
+      border-radius: ${spacing.borderRadius.small}px;
       font-size: ${typography.size.s1}px;
     `};
 `;

--- a/src/components/tooltip/TooltipLinkList.js
+++ b/src/components/tooltip/TooltipLinkList.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { ListItem } from './ListItem';
+import { spacing } from '../shared/styles';
 
 const List = styled.ul`
   min-width: 180px;
-  border-radius: 4px;
+  border-radius: ${spacing.borderRadius.small}px;
   overflow: hidden;
   margin: 0;
   padding: 0;

--- a/src/components/tooltip/TooltipNote.js
+++ b/src/components/tooltip/TooltipNote.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { color, typography } from '../shared/styles';
+import { color, typography, spacing } from '../shared/styles';
 
 const Note = styled.div`
   padding: 2px 6px;
@@ -11,7 +11,7 @@ const Note = styled.div`
   font-weight: ${typography.weight.bold};
   color: ${color.lightest};
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
+  border-radius: ${spacing.borderRadius.small}px;
   white-space: nowrap;
   pointer-events: none;
   z-index: -1;


### PR DESCRIPTION
Use border-radius variable from shared styles instead of an absolute value.

In practice, this changes the border radius of some elements from 4px to 5px.