### PR TITLE
Forward ref for button, link components

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { darken, rgba, opacify } from 'polished';
@@ -453,20 +453,28 @@ ButtonComponentPicker.defaultProps = {
   ...buttonStyleDefaultProps,
 };
 
-export function Button({ children, isDisabled, isLoading, loadingText, ...rest }) {
-  const content = (
-    <>
-      <Text>{children}</Text>
-      {isLoading && <Loading>{loadingText || 'Loading...'}</Loading>}
-    </>
-  );
+export const Button = forwardRef(
+  ({ children, isDisabled, isLoading, loadingText, ...rest }, ref) => {
+    const content = (
+      <>
+        <Text>{children}</Text>
+        {isLoading && <Loading>{loadingText || 'Loading...'}</Loading>}
+      </>
+    );
 
-  return (
-    <StyledButton as={ButtonComponentPicker} disabled={isDisabled} isLoading={isLoading} {...rest}>
-      {content}
-    </StyledButton>
-  );
-}
+    return (
+      <StyledButton
+        as={ButtonComponentPicker}
+        disabled={isDisabled}
+        isLoading={isLoading}
+        ref={ref}
+        {...rest}
+      >
+        {content}
+      </StyledButton>
+    );
+  }
+);
 
 Button.propTypes = {
   ...buttonStyleProps,

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { darken } from 'polished';
@@ -178,7 +178,7 @@ LinkComponentPicker.defaultProps = {
 /**
  * Links can contains text and/or icons. Be careful using only icons, you must provide a text alternative via aria-label for accessibility.
  */
-export function Link({ children, withArrow, ...rest }) {
+export const Link = forwardRef(({ children, withArrow, ...rest }, ref) => {
   const content = (
     <>
       <LinkInner withArrow={withArrow}>
@@ -189,11 +189,11 @@ export function Link({ children, withArrow, ...rest }) {
   );
 
   return (
-    <StyledLink as={LinkComponentPicker} {...rest}>
+    <StyledLink as={LinkComponentPicker} ref={ref} {...rest}>
       {content}
     </StyledLink>
   );
-}
+});
 
 Link.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
Partial implementation of #159 

I am basically adding this because of:

https://github.com/vercel/next.js/issues/7915

Now all function children of next's `Link` component need to forwardRefs. I am keeping it to just the `Button` and `Link` for now as that is likely all that is a child of a link. Happy to upgrade other components if necessary, but don't want to over-optimize.