### PR TITLE
Fix Loading AvatarList Not Showing in Stories

### DIFF
--- a/src/components/AvatarList.stories.js
+++ b/src/components/AvatarList.stories.js
@@ -34,7 +34,7 @@ export default {
   excludeStories: ['users'],
 };
 
-export const Basic = args => <AvatarList {...args} />;
+export const Basic = (args) => <AvatarList {...args} />;
 Basic.args = { users };
 
 export const Short = Basic.bind();
@@ -50,7 +50,7 @@ export const SmallSize = Basic.bind();
 SmallSize.args = { users, userCount: 100, size: 'small' };
 
 export const Loading = Basic.bind();
-Loading.args = { users: [], isLoading: true };
+Loading.args = { users, userCount: 100, isLoading: true };
 
 export const Empty = Basic.bind();
 Empty.args = { users: [] };

--- a/src/components/AvatarList.stories.js
+++ b/src/components/AvatarList.stories.js
@@ -50,7 +50,7 @@ export const SmallSize = Basic.bind();
 SmallSize.args = { users, userCount: 100, size: 'small' };
 
 export const Loading = Basic.bind();
-Loading.args = { users, userCount: 100, isLoading: true };
+Loading.args = { users: undefined, isLoading: true };
 
 export const Empty = Basic.bind();
 Empty.args = { users: [] };


### PR DESCRIPTION
**Description**

A tiny PR for showing the loading avatar-list example in stories as it was not showing and instead, it displays empty avatar-list.

**Checklist**

- [x] Add users and userCount to the loading avatar story. 
- [x] Fix prettier warning for always add parentheses around arrow function (fixed automatically when I run prettier command on the file from my text editor)   