### PR TITLE
Add hoverable effect to shared styles

### DIFF
--- a/src/components/SharedStyles.stories.tsx
+++ b/src/components/SharedStyles.stories.tsx
@@ -12,7 +12,15 @@ const BlockWithMargin = styled.div`
   background-color: #333;
 `;
 
-export const PageMargins = () => <BlockWithMargin />;
+export const PageMargins = () => (
+  <div>
+    <p>
+      The box below has <code>pageMargins</code> styles applied to it which controls the horizontal
+      padding and margin
+    </p>
+    <BlockWithMargin />
+  </div>
+);
 
 const BlockWithHoverEffect = styled.div`
   ${hoverEffect};
@@ -20,7 +28,7 @@ const BlockWithHoverEffect = styled.div`
   height: 300px;
 `;
 
-export const HoverEffectDefault = () => <BlockWithHoverEffect />;
+export const HoverEffectRest = () => <BlockWithHoverEffect />;
 
 export const HoverEffectHover = () => <BlockWithHoverEffect className="__hover" />;
 

--- a/src/components/SharedStyles.stories.tsx
+++ b/src/components/SharedStyles.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import { pageMargins, hoverEffect } from './shared/styles';
+
+export default {
+  title: 'Design System/SharedStyles',
+};
+
+const BlockWithMargin = styled.div`
+  ${pageMargins};
+  height: 300px;
+  background-color: #333;
+`;
+
+export const PageMargins = () => <BlockWithMargin />;
+
+const BlockWithHoverEffect = styled.div`
+  ${hoverEffect};
+  display: block;
+  height: 300px;
+`;
+
+export const HoverEffectDefault = () => <BlockWithHoverEffect />;
+
+export const HoverEffectHover = () => <BlockWithHoverEffect className="__hover" />;
+
+export const HoverEffectActive = () => <BlockWithHoverEffect className="__active" />;

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -1,4 +1,5 @@
 import { css } from 'styled-components';
+import { rgba } from 'polished';
 
 // Global style variables
 export const background = {
@@ -94,5 +95,25 @@ export const pageMargins = css`
   }
   @media (min-width: ${breakpoint * 4}px) {
     margin: 0 ${pageMargin * 4}%;
+  }
+`;
+
+export const hoverEffect = css`
+  border: 1px solid ${color.border};
+  border-radius: ${spacing.borderRadius.small}px;
+  transition: background 150ms ease-out, border 150ms ease-out,
+    transform 150ms ease-out;
+
+  &:hover,
+  &.__hover {
+    border-color: ${rgba(color.secondary, 0.5)};
+    transform: translate3d(0, -3px, 0);
+    box-shadow: rgba(0, 0, 0, 0.08) 0 3px 10px 0;
+  }
+
+  &:active,
+  &.__active {
+    border-color: ${rgba(color.secondary, 1)};
+    transform: translate3d(0, 0, 0);
   }
 `;


### PR DESCRIPTION
@domyen In the spec doc you mentioned using `color.primary` however I think you meant `color.secondary`. I also included the base, active and border-radius styles here. 