### PR TITLE
Change grave accents to single quotes

### DIFF
--- a/src/Intro.stories.mdx
+++ b/src/Intro.stories.mdx
@@ -21,7 +21,7 @@ Add SDS to your project.
 
 Import components you want into your UI
 
-`import { Button, Badge } from ‘@storybook/design-system’;`
+`import { Button, Badge } from '@storybook/design-system';`
 
 and use them like so
 


### PR DESCRIPTION
I think this code includes grave accents instead of single quotes.

```js
`import { Button, Badge } from ‘@storybook/design-system’;`
```

https://github.com/storybookjs/design-system/blame/6c2208fbb50d209f4a71337fde149b604610ad05/src/Intro.stories.mdx#L24

I tried to copy and paste it to my source code, but the code doesn't work fine.

Please merge this PR if you need it. 