### PR TITLE
Fix clipboard logic to reset state

### DIFF
--- a/src/components/clipboard/Clipboard.tsx
+++ b/src/components/clipboard/Clipboard.tsx
@@ -39,7 +39,7 @@ export const Clipboard = ({
     if (copied && timeoutId) {
       clearTimeout(timeoutId);
     }
-    if (copied && resetTimeout && timeoutId) {
+    if (copied && resetTimeout) {
       timeoutId = setTimeout(() => setCopied(false), resetTimeout);
     }
     return () => {


### PR DESCRIPTION
Small bug introduced in the refactor at #222 . The timeout never gets called.