### PR TITLE
Add function support for errors on textarea, startFocused behavior

### DIFF
--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -52,7 +52,7 @@ const LabelWrapper = styled.div`
 const Subtext = styled.div``;
 
 const TextareaText = styled.textarea`
-  ::placeholder: ${color.medium};
+  ::placeholder: ${color.mediumdark};
   appearance: none;
   border: none;
   box-sizing: border-box;

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -244,7 +244,7 @@ Textarea.propTypes = {
   label: PropTypes.string.isRequired,
   hideLabel: PropTypes.bool,
   orientation: PropTypes.oneOf(['vertical', 'horizontal']),
-  error: PropTypes.string,
+  error: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   startFocused: PropTypes.bool,
   subtext: PropTypes.string,
   subtextSentiment: PropTypes.oneOf(['default', 'negative', 'warning']),

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { color, typography } from './shared/styles';
@@ -163,54 +163,79 @@ const TextareaContainer = styled.div`
     `}
 `;
 
-export function Textarea({
-  id,
-  value,
-  label,
-  hideLabel,
-  error,
-  subtext,
-  subtextSentiment,
-  appearance,
-  orientation,
-  className,
-  ...other
-}) {
-  const errorId = `${id}-error`;
-  const subtextId = `${id}-subtext`;
+const getErrorMessage = ({ error, value }) => (typeof error === 'function' ? error(value) : error);
 
-  const ariaDescribedBy = `${error ? errorId : ''} ${subtext ? subtextId : ''}`;
+export const Textarea = forwardRef(
+  (
+    {
+      id,
+      value,
+      label,
+      hideLabel,
+      error,
+      subtext,
+      subtextSentiment,
+      appearance,
+      orientation,
+      className,
+      startFocused,
+      ...rest
+    },
+    ref
+  ) => {
+    // Outside refs take precedence
+    const textareaRef = ref || useRef();
+    const didFocusOnStart = useRef(false);
+    useEffect(() => {
+      if (textareaRef && textareaRef.current && startFocused && !didFocusOnStart.current) {
+        textareaRef.current.focus();
+        didFocusOnStart.current = true;
+      }
+    }, [textareaRef, textareaRef.current, didFocusOnStart, didFocusOnStart.current]);
 
-  return (
-    <TextareaContainer orientation={orientation} className={className}>
-      <LabelWrapper appearance={appearance} hideLabel={hideLabel} error={error}>
-        <Label htmlFor={id} hideLabel={hideLabel}>
-          {label}
-        </Label>
-        {error && (
-          <ErrorMessage id={errorId} aria-hidden>
-            {error}
-          </ErrorMessage>
-        )}
-      </LabelWrapper>
-      <TextareaWrapper error={error} appearance={appearance}>
-        <TextareaText
-          id={id}
-          value={value}
-          rows="7"
-          aria-invalid={!!error}
-          aria-describedby={ariaDescribedBy}
-          {...other}
-        />
-        {subtext && (
-          <Subtext id={subtextId} sentiment={subtextSentiment}>
-            {subtext}
-          </Subtext>
-        )}
-      </TextareaWrapper>
-    </TextareaContainer>
-  );
-}
+    const [errorMessage, setErrorMessage] = useState(getErrorMessage({ error, value }));
+
+    useEffect(() => {
+      setErrorMessage(getErrorMessage({ error, value }));
+    }, [value, error]);
+
+    const errorId = `${id}-error`;
+    const subtextId = `${id}-subtext`;
+
+    const ariaDescribedBy = `${error ? errorId : ''} ${subtext ? subtextId : ''}`;
+
+    return (
+      <TextareaContainer orientation={orientation} className={className}>
+        <LabelWrapper appearance={appearance} hideLabel={hideLabel} error={errorMessage}>
+          <Label htmlFor={id} hideLabel={hideLabel}>
+            {label}
+          </Label>
+          {errorMessage && (
+            <ErrorMessage id={errorId} aria-hidden>
+              {errorMessage}
+            </ErrorMessage>
+          )}
+        </LabelWrapper>
+        <TextareaWrapper error={errorMessage} appearance={appearance}>
+          <TextareaText
+            id={id}
+            value={value}
+            rows="7"
+            aria-invalid={!!error}
+            aria-describedby={ariaDescribedBy}
+            ref={textareaRef}
+            {...rest}
+          />
+          {subtext && (
+            <Subtext id={subtextId} sentiment={subtextSentiment}>
+              {subtext}
+            </Subtext>
+          )}
+        </TextareaWrapper>
+      </TextareaContainer>
+    );
+  }
+);
 
 Textarea.propTypes = {
   id: PropTypes.string.isRequired,
@@ -220,6 +245,7 @@ Textarea.propTypes = {
   hideLabel: PropTypes.bool,
   orientation: PropTypes.oneOf(['vertical', 'horizontal']),
   error: PropTypes.string,
+  startFocused: PropTypes.bool,
   subtext: PropTypes.string,
   subtextSentiment: PropTypes.oneOf(['default', 'negative', 'warning']),
   className: PropTypes.string,
@@ -230,6 +256,7 @@ Textarea.defaultProps = {
   hideLabel: false,
   orientation: 'vertical',
   error: null,
+  startFocused: false,
   subtext: null,
   subtextSentiment: 'default',
   className: null,

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -52,7 +52,9 @@ const LabelWrapper = styled.div`
 const Subtext = styled.div``;
 
 const TextareaText = styled.textarea`
-  ::placeholder: ${color.mediumdark};
+  ::placeholder {
+    ${color.mediumdark};
+  }
   appearance: none;
   border: none;
   box-sizing: border-box;

--- a/src/components/Textarea.js
+++ b/src/components/Textarea.js
@@ -53,7 +53,7 @@ const Subtext = styled.div``;
 
 const TextareaText = styled.textarea`
   ::placeholder {
-    ${color.mediumdark};
+    color: ${color.mediumdark};
   }
   appearance: none;
   border: none;

--- a/src/components/Textarea.stories.js
+++ b/src/components/Textarea.stories.js
@@ -53,6 +53,15 @@ export const defaultStory = () => (
       onChange={onChange}
     />
     <Textarea
+      id="Focus"
+      label="Textarea with focus on start"
+      hideLabel
+      value="startFocused"
+      placeholder="Focused"
+      onChange={onChange}
+      startFocused
+    />
+    <Textarea
       id="With-value"
       label="Textarea with value"
       hideLabel
@@ -74,6 +83,14 @@ export const defaultStory = () => (
       hideLabel
       value="Error"
       error="There's a snake in my boots"
+      onChange={onChange}
+    />
+    <Textarea
+      id="Error"
+      label="Textarea with error"
+      hideLabel
+      value="Error"
+      error={() => `There's a snake in my boots (Function error)`}
       onChange={onChange}
     />
     <Textarea
@@ -108,6 +125,16 @@ export const secondary = () => (
       onChange={onChange}
     />
     <Textarea
+      id="Focus"
+      label="Textarea with focus on start"
+      hideLabel
+      value="startFocused"
+      placeholder="Focused"
+      appearance="secondary"
+      onChange={onChange}
+      startFocused
+    />
+    <Textarea
       id="With-value"
       label="Textarea with value"
       hideLabel
@@ -131,6 +158,15 @@ export const secondary = () => (
       hideLabel
       value="Error"
       error="There's a snake in my boots"
+      appearance="secondary"
+      onChange={onChange}
+    />
+    <Textarea
+      id="Error"
+      label="Textarea with error"
+      hideLabel
+      value="Error"
+      error={() => `There's a snake in my boots (Function error)`}
       appearance="secondary"
       onChange={onChange}
     />
@@ -166,6 +202,16 @@ export const tertiary = () => (
       onChange={onChange}
     />
     <Textarea
+      id="Focus"
+      label="Textarea with focus on start"
+      hideLabel
+      value="startFocused"
+      placeholder="Focused"
+      appearance="tertiary"
+      onChange={onChange}
+      startFocused
+    />
+    <Textarea
       id="With-value"
       label="Textarea with value"
       hideLabel
@@ -189,6 +235,15 @@ export const tertiary = () => (
       hideLabel
       value="Error"
       error="There's a snake in my boots"
+      appearance="tertiary"
+      onChange={onChange}
+    />
+    <Textarea
+      id="Error"
+      label="Textarea with error"
+      hideLabel
+      value="Error"
+      error={() => `There's a snake in my boots (Function error)`}
       appearance="tertiary"
       onChange={onChange}
     />

--- a/src/components/Textarea.stories.js
+++ b/src/components/Textarea.stories.js
@@ -48,7 +48,6 @@ export const defaultStory = () => (
       id="Placeholder"
       label="Textarea with placeholder"
       hideLabel
-      value="placeholder"
       placeholder="Placeholder"
       onChange={onChange}
     />
@@ -119,7 +118,6 @@ export const secondary = () => (
       id="Placeholder"
       label="Textarea with placeholder"
       hideLabel
-      value="placeholder"
       placeholder="Placeholder"
       appearance="secondary"
       onChange={onChange}
@@ -196,7 +194,6 @@ export const tertiary = () => (
       id="Placeholder"
       label="Textarea with placeholder"
       hideLabel
-      value="placeholder"
       placeholder="Placeholder"
       appearance="tertiary"
       onChange={onChange}
@@ -273,7 +270,6 @@ export const code = () => (
       id="Placeholder"
       label="Textarea with placeholder"
       hideLabel
-      value="placeholder"
       placeholder="Code placeholder"
       appearance="code"
       onChange={onChange}


### PR DESCRIPTION
This PR adds some logic that was already ported over to inputs. We now support an error function being passed in as well as the old approach of an error string. On top of that, we can have the textarea `startFocused`. Doing this aligns the textarea with the behavior that was setup for form validation recently.