### PR TITLE
Allow customization of form error state placement

### DIFF
--- a/src/components/FormErrorState.stories.tsx
+++ b/src/components/FormErrorState.stories.tsx
@@ -14,7 +14,6 @@ import {
 import { Button } from './Button';
 // @ts-ignore
 import { Input as UnstyledInput } from './Input';
-import { breakpoint } from './shared/styles';
 
 export default {
   title: 'forms/FormErrorState',
@@ -23,10 +22,6 @@ export default {
 
 const FormWrapper = styled.div`
   padding: 3em 2em;
-
-  @media (min-width: ${breakpoint}px) {
-    padding: 3em 12em;
-  }
 `;
 
 const Input = styled(UnstyledInput)`
@@ -108,9 +103,4 @@ PureMultipleErrors.args = {
   primaryFieldId: 'input-2',
   blurredFieldIds: new Set(['input-1', 'input-2']),
   children: Children,
-};
-PureMultipleErrors.story = {
-  parameters: {
-    chromatic: { viewports: [breakpoint - 1, 1200] },
-  },
 };

--- a/src/components/FormErrorState.stories.tsx
+++ b/src/components/FormErrorState.stories.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from './Button';
 // @ts-ignore
 import { Input as UnstyledInput } from './Input';
+import { breakpoint } from './shared/styles';
 
 export default {
   title: 'forms/FormErrorState',
@@ -21,7 +22,11 @@ export default {
 };
 
 const FormWrapper = styled.div`
-  padding: 3em 12em;
+  padding: 3em 2em;
+
+  @media (min-width: ${breakpoint}px) {
+    padding: 3em 12em;
+  }
 `;
 
 const Input = styled(UnstyledInput)`
@@ -103,4 +108,9 @@ PureMultipleErrors.args = {
   primaryFieldId: 'input-2',
   blurredFieldIds: new Set(['input-1', 'input-2']),
   children: Children,
+};
+PureMultipleErrors.story = {
+  parameters: {
+    chromatic: { viewports: [breakpoint - 1, 1200] },
+  },
 };

--- a/src/components/FormErrorState.stories.tsx
+++ b/src/components/FormErrorState.stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 const FormWrapper = styled.div`
-  padding: 3em 2em;
+  padding: 3em 12em;
 `;
 
 const Input = styled(UnstyledInput)`

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -5,7 +5,7 @@ import { color, typography, spacing } from './shared/styles';
 import { jiggle } from './shared/animation';
 import { Icon } from './Icon';
 import { Link } from './Link';
-import WithTooltip from './tooltip/WithTooltip';
+import WithTooltip, { validPlacements as validTooltipPlacements } from './tooltip/WithTooltip';
 import { TooltipMessage } from './tooltip/TooltipMessage';
 
 // prettier-ignore
@@ -358,7 +358,7 @@ PureInput.propTypes = {
   id: PropTypes.string.isRequired,
   value: PropTypes.string,
   appearance: PropTypes.oneOf(['default', 'secondary', 'tertiary', 'pill', 'code']),
-  errorTooltipPlacement: PropTypes.string,
+  errorTooltipPlacement: PropTypes.oneOf(validTooltipPlacements),
   stackLevel: PropTypes.oneOf(['top', 'middle', 'bottom']),
   label: PropTypes.string.isRequired,
   hideLabel: PropTypes.bool,

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -327,7 +327,7 @@ export const PureInput = forwardRef(
           */}
           <ErrorTooltip
             tabIndex={-1}
-            placement="right"
+            placement="auto-end"
             trigger="none"
             startOpen
             tagName="div"

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -268,6 +268,7 @@ export const PureInput = forwardRef(
       icon,
       error,
       appearance,
+      errorTooltipPlacement,
       className,
       lastErrorValue,
       startingType,
@@ -327,7 +328,7 @@ export const PureInput = forwardRef(
           */}
           <ErrorTooltip
             tabIndex={-1}
-            placement="auto-end"
+            placement={errorTooltipPlacement}
             trigger="none"
             startOpen
             tagName="div"
@@ -357,6 +358,7 @@ PureInput.propTypes = {
   id: PropTypes.string.isRequired,
   value: PropTypes.string,
   appearance: PropTypes.oneOf(['default', 'secondary', 'tertiary', 'pill', 'code']),
+  errorTooltipPlacement: PropTypes.string,
   stackLevel: PropTypes.oneOf(['top', 'middle', 'bottom']),
   label: PropTypes.string.isRequired,
   hideLabel: PropTypes.bool,
@@ -374,6 +376,7 @@ PureInput.propTypes = {
 PureInput.defaultProps = {
   value: '',
   appearance: 'default',
+  errorTooltipPlacement: 'right',
   stackLevel: undefined,
   hideLabel: false,
   orientation: 'vertical',

--- a/src/components/Input.stories.js
+++ b/src/components/Input.stories.js
@@ -140,7 +140,7 @@ const All = ({ appearance }) => (
       placeholder="Error with icon"
       icon="email"
       error="There's a snake in my boots"
-      errorTooltipPlacement="bottom"
+      errorTooltipPlacement="left"
       onChange={onChange}
       appearance={appearance}
     />

--- a/src/components/Input.stories.js
+++ b/src/components/Input.stories.js
@@ -140,6 +140,7 @@ const All = ({ appearance }) => (
       placeholder="Error with icon"
       icon="email"
       error="There's a snake in my boots"
+      errorTooltipPlacement="bottom"
       onChange={onChange}
       appearance={appearance}
     />

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -169,11 +169,17 @@ function WithTooltip({
   );
 }
 
+const placementVariations = ['start', 'end'];
+export const validPlacements = ['auto', 'top', 'right', 'left', 'bottom'].flatMap((placement) => [
+  placement,
+  ...placementVariations.map((variation) => `${placement}-${variation}`),
+]);
+
 WithTooltip.propTypes = {
   tagName: PropTypes.string,
   trigger: PropTypes.string,
   closeOnClick: PropTypes.bool,
-  placement: PropTypes.string,
+  placement: PropTypes.oneOf(validPlacements),
   modifiers: PropTypes.shape({}),
   hasChrome: PropTypes.bool,
   tooltip: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),


### PR DESCRIPTION
Fixes: 
![Screen Shot 2021-02-23 at 3 36 59 PM](https://user-images.githubusercontent.com/3035355/108917464-00707100-75ed-11eb-9a87-185c62bed5ca.png)

Unfortunately, there isn't a great way to customize the positioning based on browser window & it is a bit of a pain to setup event listeners for this sort of thing. With that in mind, I chose the `auto-end` positioning (see: https://popper.js.org/docs/v1/#popperplacements--codeenumcode) which typically means that the tooltip shows up underneath the input and at the very right side of it. I think this is better than just "auto" which places it on the bottom & centered, but maybe it is just a personal preference.

@domyen thoughts on this? We seem to be slightly limited by what the lib will let us do.
