### PR TITLE
Ensure outline appears on LinkButton keyboard focus

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -131,7 +131,6 @@ const LinkButton = styled.button`
   padding: 0;
   font: inherit;
   cursor: pointer;
-  outline: inherit;
 `;
 
 /**


### PR DESCRIPTION
## Description
Fixes an issue regarding keyboard-focusing of certain buttons. These updates ensure `LinkButton`s properly display outlines based on system preference and CSS overrides.

## Changes
* `Link`: remove inherited outline from `LinkButton`

## Screenshots
### Before
![4979-link-before](https://user-images.githubusercontent.com/17681528/122608999-d8e16080-d042-11eb-8522-e68c216bedd3.gif)

### After
![4979-link-after](https://user-images.githubusercontent.com/17681528/122609008-dbdc5100-d042-11eb-8fa8-d90bf82018a4.gif)


Relates to [4979](https://github.com/chromaui/chromatic/issues/4979)