### PR TITLE
Support z index for WithTooltip & Tooltip

### DIFF
--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -101,8 +101,7 @@ export const pageMargins = css`
 export const hoverEffect = css`
   border: 1px solid ${color.border};
   border-radius: ${spacing.borderRadius.small}px;
-  transition: background 150ms ease-out, border 150ms ease-out,
-    transform 150ms ease-out;
+  transition: background 150ms ease-out, border 150ms ease-out, transform 150ms ease-out;
 
   &:hover,
   &.__hover {
@@ -117,3 +116,7 @@ export const hoverEffect = css`
     transform: translate3d(0, 0, 0);
   }
 `;
+
+export const zIndex = {
+  tooltip: 2147483647,
+};

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -44,7 +44,7 @@ const Arrow = styled.div`
 
 const TooltipWrapper = styled.div`
   display: ${(props) => (props.hidden ? 'none' : 'inline-block')};
-  z-index: 2147483647;
+  z-index: ${(props) => props.zIndex || '2147483647'};
 
   ${(props) =>
     !props.hasChrome &&
@@ -80,10 +80,17 @@ export function Tooltip({
   arrowProps,
   tooltipRef,
   arrowRef,
+  zIndex,
   ...props
 }) {
   return (
-    <TooltipWrapper hasChrome={hasChrome} data-placement={placement} ref={tooltipRef} {...props}>
+    <TooltipWrapper
+      hasChrome={hasChrome}
+      data-placement={placement}
+      ref={tooltipRef}
+      zIndex={zIndex}
+      {...props}
+    >
       <Arrow isVisible={hasChrome} data-placement={placement} ref={arrowRef} {...arrowProps} />
       {children}
     </TooltipWrapper>
@@ -98,6 +105,7 @@ Tooltip.propTypes = {
   placement: PropTypes.string,
   arrowRef: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   tooltipRef: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+  zIndex: PropTypes.number,
 };
 Tooltip.defaultProps = {
   children: undefined,
@@ -106,4 +114,5 @@ Tooltip.defaultProps = {
   arrowProps: null,
   arrowRef: undefined,
   tooltipRef: undefined,
+  zIndex: undefined,
 };

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { typography, spacing } from '../shared/styles';
+import { typography, spacing, zIndex as sharedZIndex } from '../shared/styles';
 
 const ifPlacementEquals = (placement, value, fallback = 0) => (props) =>
   props['data-placement'].split('-')[0] === placement ? value : fallback;
@@ -44,7 +44,7 @@ const Arrow = styled.div`
 
 const TooltipWrapper = styled.div`
   display: ${(props) => (props.hidden ? 'none' : 'inline-block')};
-  z-index: ${(props) => props.zIndex || '2147483647'};
+  z-index: ${(props) => props.zIndex};
 
   ${(props) =>
     !props.hasChrome &&
@@ -114,5 +114,5 @@ Tooltip.defaultProps = {
   arrowProps: null,
   arrowRef: undefined,
   tooltipRef: undefined,
-  zIndex: undefined,
+  zIndex: sharedZIndex.tooltip,
 };

--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -102,6 +102,7 @@ function WithTooltip({
   startOpen,
   delayHide,
   onVisibilityChange,
+  tooltipZIndex,
   ...props
 }) {
   const id = React.useMemo(() => uuid.v4(), []);
@@ -152,6 +153,7 @@ function WithTooltip({
           id={id}
           role="tooltip"
           hasTooltipContent={!!tooltip}
+          zIndex={tooltipZIndex}
         >
           {typeof tooltip === 'function' ? tooltip({ onHide: closeTooltip }) : tooltip}
         </StyledTooltip>
@@ -192,6 +194,7 @@ WithTooltip.propTypes = {
   startOpen: PropTypes.bool,
   delayHide: PropTypes.number,
   onVisibilityChange: PropTypes.func,
+  tooltipZIndex: PropTypes.number,
 };
 
 WithTooltip.defaultProps = {
@@ -205,6 +208,7 @@ WithTooltip.defaultProps = {
   startOpen: false,
   delayHide: 100,
   onVisibilityChange: () => {},
+  tooltipZIndex: undefined,
 };
 
 export default WithTooltip;


### PR DESCRIPTION
In situations where the tooltip should not sit above every other piece of content, we should allow customization of the z index.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.5-canary.283.e52e5d5.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@5.6.5-canary.283.e52e5d5.0
  # or 
  yarn add @storybook/design-system@5.6.5-canary.283.e52e5d5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
