### PR TITLE
add types being generated before publishing & fix 2 typing issues

### DIFF
--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -1,4 +1,4 @@
-name: "Chromatic"
+name: "Type Checking"
 on:
   push
 

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -1,0 +1,13 @@
+name: "Chromatic"
+on:
+  push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: |
+        yarn
+    - run: |
+        yarn types

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   ],
   "scripts": {
     "build": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\" --ignore \"**/*.test.js\" --ignore \"**/*.stories.js\"",
+    "types": "tsc --declaration --emitDeclarationOnly --outDir dist --declarationMap",
     "build-docs": "build-storybook --docs",
     "build-storybook": "build-storybook -s .storybook/static",
     "lint": "yarn lint:js && yarn lint:package",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
     "lint:package": "sort-package-json",
-    "release": "dotenv yarn build && auto shipit",
+    "release": "dotenv yarn build & yarn types && auto shipit",
     "storybook": "start-storybook -p 6006 -s .storybook/static"
   },
   "husky": {

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -153,5 +153,5 @@ interface Props {
   src: string;
   /** Specify size */
   size: keyof typeof sizes;
-  type: AvatarType;
+  type?: AvatarType;
 }

--- a/src/components/clipboard/ClipboardInput.tsx
+++ b/src/components/clipboard/ClipboardInput.tsx
@@ -1,16 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-// @ts-ignore
 import { Input } from '../Input';
-import { color, spacing } from '../shared/styles';
 import { ClipboardIcon } from './ClipboardIcon';
 
 const Container = styled.div`
   position: relative;
 `;
 
-const StyledInput = styled(Input)`
+const StyledInput = styled(Input as any)`
   width: 100%;
   display: block;
   && input {
@@ -24,15 +21,16 @@ const StyledClipboardIcon = styled(ClipboardIcon)`
   right: 4px;
 `;
 
-interface ClipboardInputProps extends React.ComponentPropsWithoutRef<typeof Input> {
+type SubProps = React.ComponentPropsWithoutRef<typeof Input>;
+interface ClipboardInputProps extends SubProps {
   value: string;
 }
 
 export const ClipboardInput = ({ value, ...props }: ClipboardInputProps) => (
   <Container>
     <StyledInput
-      {...props}
       id="clipboard-input"
+      {...props}
       icon={undefined}
       hideLabel
       value={value}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
     "baseUrl": ".",
     "incremental": false,
     "noImplicitAny": true,
@@ -16,12 +18,16 @@
     "types": ["jest"],
     "lib": ["es2017", "dom"]
   },
+  "include": [
+    "src"
+  ],
   "exclude": [
     "**/dist",
     "node_modules",
     "**/node_modules",
     "**/*.spec.ts",
     "**/__tests__",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "**/*.stories.*"
   ]
 }


### PR DESCRIPTION
To get better typescript support in the chromatic codebase we need types to be present in the design-system.

This PR adds scripting to generate .d.ts files in dist when a release is made
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.6-canary.287.9ce3cd3.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@5.6.6-canary.287.9ce3cd3.0
  # or 
  yarn add @storybook/design-system@5.6.6-canary.287.9ce3cd3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
