### PR TITLE
Support external portalContainer in WithTooltip

### DIFF
--- a/src/components/tooltip/WithTooltip.js
+++ b/src/components/tooltip/WithTooltip.js
@@ -102,6 +102,7 @@ function WithTooltip({
   startOpen,
   delayHide,
   onVisibilityChange,
+  portalContainer,
   tooltipZIndex,
   ...props
 }) {
@@ -123,7 +124,7 @@ function WithTooltip({
   };
 
   /* eslint-env browser */
-  const portalContainer =
+  const defaultPortalContainer =
     typeof window !== 'undefined' ? document.getElementById('root') || document.body : undefined;
 
   return (
@@ -134,7 +135,7 @@ function WithTooltip({
       tooltipShown={isTooltipShown}
       onVisibilityChange={handleVisibilityChange}
       modifiers={modifiers}
-      portalContainer={portalContainer}
+      portalContainer={portalContainer || defaultPortalContainer}
       tooltip={({
         getTooltipProps,
         getArrowProps,
@@ -194,6 +195,7 @@ WithTooltip.propTypes = {
   startOpen: PropTypes.bool,
   delayHide: PropTypes.number,
   onVisibilityChange: PropTypes.func,
+  portalContainer: PropTypes.node,
   tooltipZIndex: PropTypes.number,
 };
 
@@ -204,6 +206,7 @@ WithTooltip.defaultProps = {
   placement: 'top',
   modifiers: {},
   tooltip: undefined,
+  portalContainer: undefined,
   hasChrome: true,
   startOpen: false,
   delayHide: 100,


### PR DESCRIPTION
On a current project, we need to render the tooltip somewhere other than just nested under the `#root` for z-index reasons. The library supports this, so I am adding the option to pass down a `portalContainer` DOM node.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>5.6.8-canary.291.aa01f64.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@5.6.8-canary.291.aa01f64.0
  # or 
  yarn add @storybook/design-system@5.6.8-canary.291.aa01f64.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
