### PR TITLE
Remove italic style from em tags

### DIFF
--- a/src/components/shared/global.ts
+++ b/src/components/shared/global.ts
@@ -56,6 +56,10 @@ export const bodyStyles = css`
     font-weight: ${typography.weight.bold};
   }
 
+  em {
+    font-style: normal;
+  }
+
   hr {
     border: none;
     border-top: 1px solid ${color.border};


### PR DESCRIPTION
## Description

We do not plan to load italicized versions of our fonts at this point. As such, we're removing that style from `em` tags.