### PR TITLE
Fixed an issue with maximum call stack size being exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "dist"
   ],
   "scripts": {
+    "patch-package": "patch-package",
     "build": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\" --ignore \"**/*.test.js\" --ignore \"**/*.stories.js\"",
-    "build-docs": "build-storybook --docs",
-    "build-storybook": "build-storybook -s .storybook/static",
+    "build-docs": "yarn patch-package && build-storybook --docs",
+    "build-storybook": "yarn patch-package && build-storybook -s .storybook/static",
     "lint": "yarn lint:js && yarn lint:package",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --ext .js,.jsx,.html,.ts,.tsx,.mjs --report-unused-disable-directives",
     "lint:package": "sort-package-json",
     "release": "dotenv yarn build & yarn typescript:generate && auto shipit",
-    "storybook": "start-storybook -p 6006 -s .storybook/static",
+    "storybook": "yarn patch-package && start-storybook -p 6006 -s .storybook/static",
     "typescript:check": "tsc --project ./tsconfig.json --noEmit",
     "typescript:generate": "tsc --declaration --emitDeclarationOnly --outDir dist --declarationMap"
   },
@@ -90,6 +91,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.9",
     "node-fetch": "^2.6.0",
+    "patch-package": "^6.4.7",
     "prettier": "^2.4.0",
     "react": "17",
     "react-dom": "17",

--- a/patches/react-element-to-jsx-string+14.3.2.patch
+++ b/patches/react-element-to-jsx-string+14.3.2.patch
@@ -1,0 +1,70 @@
+diff --git a/node_modules/react-element-to-jsx-string/dist/cjs/index.js b/node_modules/react-element-to-jsx-string/dist/cjs/index.js
+index aeeaf0c..cbc0511 100644
+--- a/node_modules/react-element-to-jsx-string/dist/cjs/index.js
++++ b/node_modules/react-element-to-jsx-string/dist/cjs/index.js
+@@ -290,8 +290,8 @@ function sortObject(value) {
+     return value;
+   } // return date and regexp values as is
+ 
+-
+-  if (value instanceof Date || value instanceof RegExp) {
++  // patch from https://github.com/algolia/react-element-to-jsx-string/pull/619
++  if (value instanceof Date || value instanceof RegExp || React__default.isValidElement(value)) {
+     return value;
+   } // make a copy of array with each item passed through sortObject()
+ 
+@@ -438,6 +438,10 @@ var formatFunction = (function (fn, options) {
+ var formatComplexDataStructure = (function (value, inline, lvl, options) {
+   var normalizedValue = sortObject(value);
+   var stringifiedValue = dist_1(normalizedValue, {
++    // patch from https://github.com/algolia/react-element-to-jsx-string/pull/620
++    filter: function filter(currentValue) {
++      return !React.isValidElement(currentValue) && typeof currentValue !== 'function';
++    },
+     transform: function transform(currentObj, prop, originalResult) {
+       var currentValue = currentObj[prop];
+ 
+@@ -450,7 +454,7 @@ var formatComplexDataStructure = (function (value, inline, lvl, options) {
+       }
+ 
+       return originalResult;
+-    }
++    },
+   });
+ 
+   if (inline) {
+diff --git a/node_modules/react-element-to-jsx-string/dist/esm/index.js b/node_modules/react-element-to-jsx-string/dist/esm/index.js
+index 230eba4..7864926 100644
+--- a/node_modules/react-element-to-jsx-string/dist/esm/index.js
++++ b/node_modules/react-element-to-jsx-string/dist/esm/index.js
+@@ -283,8 +283,8 @@ function sortObject(value) {
+     return value;
+   } // return date and regexp values as is
+ 
+-
+-  if (value instanceof Date || value instanceof RegExp) {
++  // patch from https://github.com/algolia/react-element-to-jsx-string/pull/619
++  if (value instanceof Date || value instanceof RegExp || isValidElement(value)) {
+     return value;
+   } // make a copy of array with each item passed through sortObject()
+ 
+@@ -431,6 +431,10 @@ var formatFunction = (function (fn, options) {
+ var formatComplexDataStructure = (function (value, inline, lvl, options) {
+   var normalizedValue = sortObject(value);
+   var stringifiedValue = dist_1(normalizedValue, {
++    // patch from https://github.com/algolia/react-element-to-jsx-string/pull/620
++    filter: function filter(currentValue) {
++      return !isValidElement(currentValue) && typeof currentValue !== 'function';
++    },
+     transform: function transform(currentObj, prop, originalResult) {
+       var currentValue = currentObj[prop];
+ 
+@@ -443,7 +447,7 @@ var formatComplexDataStructure = (function (value, inline, lvl, options) {
+       }
+ 
+       return originalResult;
+-    }
++    },
+   });
+ 
+   if (inline) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,11 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -6100,6 +6105,13 @@ find-versions@^4.0.0:
   dependencies:
     semver-regex "^3.1.2"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -6244,6 +6256,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
@@ -7787,6 +7808,13 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -7852,6 +7880,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 klaw@^1.0.0:
   version "1.3.1"
@@ -9002,7 +9037,7 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^7.0.2, open@^7.0.3:
+open@^7.0.2, open@^7.0.3, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.npmjs.org/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -9053,6 +9088,11 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 overlayscrollbars@^1.13.1:
   version "1.13.1"
@@ -9284,6 +9324,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -11731,6 +11790,13 @@ tmp-promise@3.0.2:
   dependencies:
     tmp "^0.2.0"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmp@^0.2.0:
   version "0.2.1"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -12230,6 +12296,11 @@ universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.1-canary.302.0d5443d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@6.2.1-canary.302.0d5443d.0
  # or 
  yarn add @storybook/design-system@6.2.1-canary.302.0d5443d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
