### PR TITLE
Fixed component selectors by patching Emotion babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,10 @@ module.exports = (api) => {
 
   return {
     presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-    plugins: ['@babel/plugin-proposal-object-rest-spread', '@babel/transform-runtime'],
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+      '@babel/transform-runtime',
+      'babel-plugin-emotion',
+    ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "auto": "^9.50.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-emotion": "^10.2.2",
     "chromatic": "^5.0.0",
     "cross-env": "^7.0.2",
     "dotenv-cli": "^3.1.0",

--- a/patches/babel-plugin-emotion+10.2.2.patch
+++ b/patches/babel-plugin-emotion+10.2.2.patch
@@ -1,0 +1,99 @@
+diff --git a/node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.dev.js b/node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.dev.js
+index 633e882..076ebf6 100644
+--- a/node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.dev.js
++++ b/node_modules/babel-plugin-emotion/dist/babel-plugin-emotion.cjs.dev.js
+@@ -745,36 +745,8 @@ var createStyledMacro = function createStyledMacro(_ref) {
+ 
+     var t = babel.types;
+ 
+-    if (references["default"] && references["default"].length) {
+-      var _styledIdentifier;
+-
+-      var getStyledIdentifier = function getStyledIdentifier() {
+-        if (_styledIdentifier === undefined) {
+-          _styledIdentifier = helperModuleImports.addDefault(state.file.path, importPath, {
+-            nameHint: 'styled'
+-          });
+-        }
+-
+-        return t.cloneDeep(_styledIdentifier);
+-      };
+-
+-      var originalImportPathStyledIdentifier;
+-
+-      var getOriginalImportPathStyledIdentifier = function getOriginalImportPathStyledIdentifier() {
+-        if (originalImportPathStyledIdentifier === undefined) {
+-          originalImportPathStyledIdentifier = helperModuleImports.addDefault(state.file.path, originalImportPath, {
+-            nameHint: 'styled'
+-          });
+-        }
+-
+-        return t.cloneDeep(originalImportPathStyledIdentifier);
+-      };
+-
+-      if (importPath === originalImportPath) {
+-        getOriginalImportPathStyledIdentifier = getStyledIdentifier;
+-      }
+-
+-      references["default"].forEach(function (reference) {
++    if (references["styled"] && references["styled"].length) {
++      references["styled"].forEach(function (reference) {
+         var isCall = false;
+ 
+         if (t.isMemberExpression(reference.parent) && reference.parent.computed === false) {
+@@ -784,15 +756,15 @@ var createStyledMacro = function createStyledMacro(_ref) {
+           // becasue we don't want to transform the member expression if
+           // it's in primitives/native
+           reference.parent.property.name.charCodeAt(0) > 96) {
+-            reference.parentPath.replaceWith(t.callExpression(getStyledIdentifier(), [t.stringLiteral(reference.parent.property.name)]));
++            reference.parentPath.replaceWith(t.callExpression(t.identifier('styled'), [t.stringLiteral(reference.parent.property.name)]));
+           } else {
+-            reference.replaceWith(getStyledIdentifier());
++            reference.replaceWith(t.identifier('styled'));
+           }
+         } else if (reference.parentPath && reference.parentPath.parentPath && t.isCallExpression(reference.parentPath) && reference.parent.callee === reference.node) {
+           isCall = true;
+-          reference.replaceWith(getStyledIdentifier());
++          reference.replaceWith(t.identifier('styled'));
+         } else {
+-          reference.replaceWith(getOriginalImportPathStyledIdentifier());
++          reference.replaceWith(t.identifier('styled'));
+         }
+ 
+         if (reference.parentPath && reference.parentPath.parentPath) {
+@@ -819,15 +791,6 @@ var createStyledMacro = function createStyledMacro(_ref) {
+         }
+       });
+     }
+-
+-    Object.keys(references).filter(function (x) {
+-      return x !== 'default';
+-    }).forEach(function (referenceKey) {
+-      var runtimeNode = helperModuleImports.addNamed(state.file.path, referenceKey, importPath);
+-      references[referenceKey].reverse().forEach(function (reference) {
+-        reference.replaceWith(t.cloneDeep(runtimeNode));
+-      });
+-    });
+   });
+ };
+ 
+@@ -1021,10 +984,6 @@ function index (babel) {
+           isBabelMacrosCall: true,
+           isEmotionCall: true
+         });
+-
+-        if (!pluginMacros[path.node.source.value].keepImport) {
+-          path.remove();
+-        }
+       },
+       Program: function Program(path, state) {
+         state.emotionInstancePaths = (state.opts.instances || []).map(function (instancePath) {
+@@ -1032,7 +991,7 @@ function index (babel) {
+         });
+         state.pluginMacros = {
+           '@emotion/css': cssMacro,
+-          '@emotion/styled': webStyledMacro,
++          '@storybook/theming': webStyledMacro,
+           '@emotion/core': emotionCoreMacroThatsNotARealMacro,
+           '@emotion/primitives': primitivesStyledMacro,
+           '@emotion/native': nativeStyledMacro,

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -64,9 +64,9 @@ const Selector = styled.select<SelectProps>`
 
 const OptionWrapper = styled.option``;
 
-const Arrow: FC<Omit<ComponentProps<typeof Icon>, 'icon'>> = (props) => (
+const Arrow = styled((props: Omit<ComponentProps<typeof Icon>, 'icon'>) => (
   <Icon {...props} icon="arrowdown" />
-);
+))``;
 
 const SelectIcon = styled(Icon)``;
 
@@ -130,7 +130,7 @@ const SelectWrapper = styled.span<WrapperProps>`
     border-radius: ${spacing.borderRadius.small}px;
   }
 
-  ${css(Arrow as unknown as string)} {
+  ${Arrow} {
     position: absolute;
     z-index: 1;
     pointer-events: none;
@@ -160,7 +160,7 @@ const SelectWrapper = styled.span<WrapperProps>`
   &:before {
     background-color: rgba(255, 255, 255, 0.9);
   }
-  ${css(Selector)} {
+  ${Selector} {
     background-color: ${color.lightest};
     color: ${color.darkest};
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,7 +3552,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.27:
+babel-plugin-emotion@^10.0.27, babel-plugin-emotion@^10.2.2:
   version "10.2.2"
   resolved "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
   integrity sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.1-canary.303.c2c26cd.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@6.2.1-canary.303.c2c26cd.0
  # or 
  yarn add @storybook/design-system@6.2.1-canary.303.c2c26cd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
