### PR TITLE
Add OutlineCTA component

### DIFF
--- a/src/components/OutlineCTA.stories.tsx
+++ b/src/components/OutlineCTA.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Badge } from './Badge';
+import { Button } from './Button';
+import { Link } from './Link';
+import { OutlineCTA } from './OutlineCTA';
+
+// The wrapper allows you to see the shadow in Chromatic
+const Wrapper = styled.div`
+  padding: 20px;
+`;
+
+const InlineWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export default {
+  component: OutlineCTA,
+  title: 'OutlineCTA',
+  argTypes: {
+    action: { control: false },
+    badge: { control: false },
+  },
+  decorators: [(story) => <Wrapper>{story()}</Wrapper>],
+};
+
+const Story = (args) => <OutlineCTA {...args} />;
+
+export const Default = Story.bind({});
+Default.args = {
+  action: (
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
+    <Link href="#" withArrow>
+      Go to latest docs
+    </Link>
+  ),
+  badge: <Badge status="positive">New</Badge>,
+  children: 'These docs are for version 6.0. Newer docs are available for version 6.4.',
+};
+
+export const NoBadge = Story.bind({});
+NoBadge.args = {
+  action: Default.args.action,
+  children: Default.args.children,
+};
+
+export const Inline = Story.bind({});
+Inline.args = {
+  ...Default.args,
+  action: (
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
+    <Link href="#" withArrow>
+      Read more
+    </Link>
+  ),
+  badge: Default.args.badge,
+  children: 'Learn how to automate UI tests with Github Actions.',
+};
+Inline.decorators = [(story) => <InlineWrapper>{story()}</InlineWrapper>];

--- a/src/components/OutlineCTA.tsx
+++ b/src/components/OutlineCTA.tsx
@@ -1,0 +1,53 @@
+import React, { ComponentProps, FC, ReactNode } from 'react';
+import styled from 'styled-components';
+
+import { breakpoint, color, spacing, typography } from './shared/styles';
+
+const OutlineCTAWrapper = styled.div`
+  border-radius: ${spacing.borderRadius.small}px;
+  box-shadow: ${color.border} 0 0 0 1px inset;
+  padding: ${spacing.padding.small}px ${spacing.padding.medium}px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  text-align: center;
+
+  @media (min-width: ${breakpoint}px) {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    text-align: left;
+  }
+`;
+
+const MessageText = styled.p`
+  font-size: ${typography.size.s2}px;
+  margin: 0;
+`;
+
+const ActionWrapper = styled.span`
+  font-size: ${typography.size.s2}px;
+  font-weight: ${typography.weight.bold};
+  white-space: nowrap;
+`;
+
+interface Props {
+  /** Displays after `children`; typically a [Link](/?path=/docs/link--basic) */
+  action: ReactNode;
+  /** Displays before `children`; should be a [Badge](/?path=/docs/badge--basic) */
+  badge?: ReactNode;
+  children: string;
+}
+
+export const OutlineCTA = ({ action, badge, children, ...rest }: Props) => (
+  <OutlineCTAWrapper {...rest}>
+    {badge}
+    <MessageText>{children}</MessageText>
+    <ActionWrapper>{action}</ActionWrapper>
+  </OutlineCTAWrapper>
+);
+
+OutlineCTA.defaultProps = {
+  badge: null,
+};

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -36,6 +36,7 @@ export * from './modal/Modal';
 export { default as WithModal } from './modal/WithModal';
 
 export * from './table-of-contents/TableOfContents';
+export * from './OutlineCTA';
 export * from './ShadowBoxCTA';
 
 export * from './clipboard/Clipboard';


### PR DESCRIPTION
### Description

- Add OutlineCTA component
   - Name and structure based on ShadowBoxCTA
   - For use within frontpage Header to highlight latest blog post and https://github.com/storybookjs/frontpage/pull/298

### Design

https://www.figma.com/file/gYdEmX9zYowUR3K2SOua5J/Component-catalog?node-id=231%3A16574

### Screenshots

![OutlineCTA](https://user-images.githubusercontent.com/486540/137948389-4d6276af-8f0d-47b2-9b20-3491f39a9590.png)

### How to test

1. Open the preview SB
2. Check rendering vs. design
3. Particularly interested in feedback on wrapping behavior both before and after the breakpoint hits

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.2.1-canary.306.62f717f.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@6.2.1-canary.306.62f717f.0
  # or 
  yarn add @storybook/design-system@6.2.1-canary.306.62f717f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
