### PR TITLE
TooltipNote: Increased the opacity of the background color

### DIFF
--- a/src/components/tooltip/TooltipNote.tsx
+++ b/src/components/tooltip/TooltipNote.tsx
@@ -14,7 +14,7 @@ const Note = styled.div`
   white-space: nowrap;
   pointer-events: none;
   z-index: -1;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.6);
   margin: 6px;
 `;
 


### PR DESCRIPTION
This was done to increase the contrast when used in Storybook and elsewhere.

### Before
![image](https://user-images.githubusercontent.com/1123119/138143912-1a5ff1a6-404f-4c29-9b11-82a3aa460f77.png)

### After
![image](https://user-images.githubusercontent.com/1123119/138143837-4c00fa91-03bd-4439-9571-1701153a4969.png)
