### PR TITLE
Pull Heading from `frontpage` into the DS

### DIFF
--- a/src/components/marketing/Heading.stories.tsx
+++ b/src/components/marketing/Heading.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Heading } from './Heading';
+
+export default {
+  title: 'Marketing/Heading',
+  component: Heading,
+};
+
+export const Default = () => <Heading>Heading</Heading>;

--- a/src/components/marketing/Heading.tsx
+++ b/src/components/marketing/Heading.tsx
@@ -1,0 +1,22 @@
+import React, { ComponentProps, FC } from 'react';
+import { styled } from '@storybook/theming';
+import { typography, color, breakpoint } from '../shared/styles';
+
+export const StyledHeading = styled.h2`
+  color: ${color.darkest};
+  font-size: ${typography.size.m3}px;
+  font-weight: ${typography.weight.black};
+  letter-spacing: -0.29px;
+  line-height: ${typography.size.l2}px;
+  margin-bottom: 4px;
+
+  @media (min-width: ${breakpoint * 1}px) {
+    font-size: 36px;
+    margin-bottom: 8px;
+    letter-spacing: -0.37px;
+  }
+`;
+
+export const Heading: FC<ComponentProps<typeof StyledHeading>> = (props) => (
+  <StyledHeading {...props} />
+);


### PR DESCRIPTION
Fixes https://linear.app/chromaui/issue/CH-738/pull-addonsheading-from-frontpage-into-ds

## Description

Pulling the AddonsHomeScreen Heading component from https://github.com/storybookjs/frontpage into the DS in preparation for future work.

### Of Note

Following [this proposal](https://www.notion.so/Styling-solutions-across-design-system-and-its-consumers-aba73999c0114448ad258ae4f0a24010) and branching off of the branch converting the DS to Emotion.

Also, I'm open to a name other than `Heading` - feel free to make a suggestion 😸 

### QA instructions

Confirm the styles (mostly) match [the designs](https://www.figma.com/file/gYdEmX9zYowUR3K2SOua5J/Component-catalog?node-id=264%3A9835).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.4.2-canary.310.f938338.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@6.4.2-canary.310.f938338.0
  # or 
  yarn add @storybook/design-system@6.4.2-canary.310.f938338.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
