### PR TITLE
Remove multiplication by one

### DIFF
--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -91,8 +91,8 @@ export const pageMargin = 5.55555;
 
 export const pageMargins = css`
   padding: 0 ${spacing.padding.medium}px;
-  @media (min-width: ${breakpoint * 1}px) {
-    margin: 0 ${pageMargin * 1}%;
+  @media (min-width: ${breakpoint}px) {
+    margin: 0 ${pageMargin}%;
   }
   @media (min-width: ${breakpoint * 2}px) {
     margin: 0 ${pageMargin * 2}%;


### PR DESCRIPTION
Remove multiplication by one as it adds calculations that won't affect any number or string

```

let breakpoint = '5'

`min-width: ${breakpoint}px`
//output: `min-width: 5px'

`min-width: ${breakpoint * 1}px`
//output: 'min-width: 5px'

breakpoint = 5

`min-width: ${breakpoint}px`
//output: 'min-width: 5px'

`min-width: ${breakpoint * 1}px`
//output: 'min-width: 5px'

```