### PR TITLE
Remove props from Icon

### DIFF
--- a/src/components/Icon.stories.tsx
+++ b/src/components/Icon.stories.tsx
@@ -79,21 +79,3 @@ export const NoLabels = () => (
     ))}
   </List>
 );
-
-export const Inline = () => (
-  <>
-    this is an inline <Icon icon="facehappy" aria-label="Happy face" /> icon (default)
-  </>
-);
-
-export const Block = () => (
-  <>
-    this is a block <Icon icon="facehappy" aria-label="Happy face" block /> icon
-  </>
-);
-
-export const CustomColor = () => (
-  <>
-    this is a colorful <Icon icon="facehappy" aria-label="Pink happy face" color="pink" /> icon
-  </>
-);

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -2,17 +2,14 @@ import React, { FunctionComponent } from 'react';
 import { styled } from '@storybook/theming';
 import { icons } from './shared/icons';
 
-const Svg = styled('svg', { shouldForwardProp: (prop) => !['block', 'color'].includes(prop) })<
-  Partial<Props>
->`
-  display: ${(props) => (props.block ? 'block' : 'inline-block')};
+const Svg = styled.svg`
   vertical-align: middle;
 
   shape-rendering: inherit;
   transform: translate3d(0, 0, 0);
 
   path {
-    fill: ${(props) => props.color};
+    fill: currentColor;
   }
 `;
 
@@ -23,14 +20,9 @@ const Svg = styled('svg', { shouldForwardProp: (prop) => !['block', 'color'].inc
  * - *decorative only*: for example, it illustrates a label next to it. We must ensure that it is ignored by screen readers, by setting `aria-hidden` attribute (ex: `<Icon icon="check" aria-hidden />`)
  * - *non-decorative*: it means that it delivers information. For example, an icon as only child in a button. The meaning can be obvious visually, but it must have a proper text alternative via `aria-label` for screen readers. (ex: `<Icon icon="print" aria-label="Print this document" />`)
  */
-export const Icon: FunctionComponent<Props> = ({
-  icon,
-  block = false,
-  color = 'currentColor',
-  ...props
-}: Props) => {
+export const Icon: FunctionComponent<Props> = ({ icon, ...props }: Props) => {
   return (
-    <Svg viewBox="0 0 1024 1024" width="20px" height="20px" block={block} color={color} {...props}>
+    <Svg viewBox="0 0 1024 1024" width="20px" height="20px" {...props}>
       <path d={icons[icon]} />
     </Svg>
   );
@@ -38,8 +30,4 @@ export const Icon: FunctionComponent<Props> = ({
 
 interface Props {
   icon: keyof typeof icons;
-  /** Pass this prop to add display: block to the Icon */
-  block?: boolean;
-  /** Set a custom color for the Icon */
-  color?: string;
 }

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -3,10 +3,10 @@ import { styled } from '@storybook/theming';
 import { icons } from './shared/icons';
 
 const Svg = styled.svg`
-  vertical-align: middle;
-
+  display: inline-block;
   shape-rendering: inherit;
   transform: translate3d(0, 0, 0);
+  vertical-align: middle;
 
   path {
     fill: currentColor;

--- a/src/components/marketing/Breadcrumb.tsx
+++ b/src/components/marketing/Breadcrumb.tsx
@@ -22,6 +22,10 @@ const BreadcrumbInner = styled.div`
   }
 `;
 
+const BreadcrumbIcon = styled(Icon)`
+  color: ${color.mediumdark};
+`;
+
 export const Breadcrumb: FunctionComponent<Props> = ({
   children,
   linkWrapper,
@@ -29,7 +33,7 @@ export const Breadcrumb: FunctionComponent<Props> = ({
 }: Props) => (
   <BreadcrumbInner>
     <BreadcrumbLink tertiary LinkWrapper={linkWrapper} {...props}>
-      <Icon icon="arrowleft" color={color.mediumdark} />
+      <BreadcrumbIcon icon="arrowleft" />
       {children}
     </BreadcrumbLink>
   </BreadcrumbInner>


### PR DESCRIPTION
Fixes https://linear.app/chromaui/issue/CH-876/remove-color-prop-from-ds-icon

## Description

Feedback from @domyen:

> Our current ergonomics are to define styles outside of the component markup (i.e., in styled and not inline). It seems like we’re moving to that even more with the *.style.ts pattern I saw in one of your PRs. I don’t think the Icon should have a color prop because it’s a departure from these ergonomics.

As such, I removed the `color` prop. I also removed the `block` prop for the same reason - it didn't seem to be used anywhere anyway.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>6.4.2-canary.315.470be8c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@6.4.2-canary.315.470be8c.0
  # or 
  yarn add @storybook/design-system@6.4.2-canary.315.470be8c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
