### PR TITLE
Pulled in `AddonsGrid-Title` component from `frontpage`

### DIFF
--- a/src/components/marketing/Title.stories.tsx
+++ b/src/components/marketing/Title.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Title } from './Title';
+
+export default {
+  title: 'Marketing/Title',
+  component: Title,
+};
+
+export const Default = () => <Title>Title</Title>;

--- a/src/components/marketing/Title.tsx
+++ b/src/components/marketing/Title.tsx
@@ -1,0 +1,12 @@
+import React, { ComponentProps, FC } from 'react';
+import { styled } from '@storybook/theming';
+import { typography, color } from '../shared/styles';
+
+const StyledTitle = styled.h3`
+  font-weight: ${typography.weight.black};
+  font-size: ${typography.size.m2}px;
+  line-height: ${typography.size.m3}px;
+  color: ${color.darkest};
+`;
+
+export const Title: FC<ComponentProps<typeof StyledTitle>> = (props) => <StyledTitle {...props} />;


### PR DESCRIPTION
Fixes https://linear.app/chromaui/issue/CH-736/pull-addonsgrid-title-from-frontpage-into-ds

## Description

Pulling the AddonsGrid Title component from https://github.com/storybookjs/frontpage into the DS in preparation for future work.

### QA instructions

Confirm the styles (mostly) match [the designs]((https://www.figma.com/file/gYdEmX9zYowUR3K2SOua5J/Component-catalog?node-id=180%3A8141).