### PR TITLE
Pulled in `AuthorList` component from `frontpage`

### DIFF
--- a/src/components/AuthorList.stories.tsx
+++ b/src/components/AuthorList.stories.tsx
@@ -33,6 +33,11 @@ export const authors = [
     name: 'Kyle Suss',
     avatarUrl: 'https://avatars2.githubusercontent.com/u/3035355?s=96&v=4',
   },
+  {
+    id: '7',
+    name: 'Kyler Suspect',
+    avatarUrl: 'https://avatars2.githubusercontent.com/u/3035355?s=96&v=4',
+  },
 ];
 
 export default {
@@ -47,5 +52,8 @@ Basic.args = { authors: authors.slice(0, 5) };
 export const Short = Basic.bind({});
 Short.args = { authors: authors.slice(0, 2) };
 
-export const ShowMore = Basic.bind({});
-ShowMore.args = { authors };
+export const ShowOneMoreAuthor = Basic.bind({});
+ShowOneMoreAuthor.args = { authors: authors.slice(0, 6) };
+
+export const ShowMultipleMoreAuthors = Basic.bind({});
+ShowMultipleMoreAuthors.args = { authors };

--- a/src/components/AuthorList.stories.tsx
+++ b/src/components/AuthorList.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { AuthorList, AuthorListProps } from './AuthorList';
+
+export const authors = [
+  {
+    id: '1',
+    name: 'Dominic Nguyen',
+    avatarUrl: 'https://avatars2.githubusercontent.com/u/263385',
+  },
+  {
+    id: '2',
+    name: 'Tom Coleman',
+    avatarUrl: 'https://avatars2.githubusercontent.com/u/132554',
+  },
+  {
+    id: '3',
+    name: 'Zoltan Olah',
+    avatarUrl: 'https://avatars0.githubusercontent.com/u/81672',
+  },
+  {
+    id: '4',
+    name: 'Tim Hingston',
+    avatarUrl: 'https://avatars3.githubusercontent.com/u/1831709',
+  },
+  {
+    id: '5',
+    name: 'Amanda Martinez',
+    avatarUrl:
+      'https://user-images.githubusercontent.com/321738/102828147-3d00d000-43e4-11eb-8585-eceb9b454d8b.jpg',
+  },
+  {
+    id: '6',
+    name: 'Kyle Suss',
+    avatarUrl: 'https://avatars2.githubusercontent.com/u/3035355?s=96&v=4',
+  },
+];
+
+export default {
+  title: 'AuthorList',
+  component: AuthorList,
+  excludeStories: ['authors'],
+};
+
+export const Basic = (args: AuthorListProps) => <AuthorList {...args} />;
+Basic.args = { authors: authors.slice(0, 5) };
+
+export const Short = Basic.bind({});
+Short.args = { authors: authors.slice(0, 2) };
+
+export const ShowMore = Basic.bind({});
+ShowMore.args = { authors };

--- a/src/components/AuthorList.tsx
+++ b/src/components/AuthorList.tsx
@@ -1,14 +1,19 @@
 import React, { useMemo } from 'react';
-import { styled } from '@storybook/theming';
+import { styled, css } from '@storybook/theming';
 import { typography, color, spacing } from './shared/styles';
 import { Avatar } from './Avatar';
 import { Link } from './Link';
+import { Icon } from './Icon';
 
-const AuthorName = styled.div`
+const authorStyles = css`
   color: ${color.darkest};
   font-size: ${typography.size.s2}px;
   line-height: ${typography.size.m1}px;
   margin-left: ${spacing.padding.small}px;
+`;
+
+const AuthorName = styled.div`
+  ${authorStyles}
 `;
 
 const Author = styled(Link)`
@@ -25,11 +30,29 @@ const AuthorListInner = styled.div`
   margin-bottom: 40px;
 `;
 
-const MoreAuthors = styled.div`
-  color: ${color.darkest};
-  font-size: ${typography.size.s2}px;
-  line-height: ${typography.size.m1}px;
-  margin-left: ${spacing.padding.small}px;
+const HiddenAuthorsWrapper = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+const IconWrapper = styled.div`
+  align-items: center;
+  background: ${color.border};
+  border-radius: 50%;
+  color: ${color.dark};
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+
+  svg {
+    height: 14px;
+    width: 14px;
+  }
+`;
+
+const HiddenAuthors = styled.div`
+  ${authorStyles}
 `;
 
 export interface AuthorListProps {
@@ -42,7 +65,7 @@ export interface AuthorListProps {
 
 export const AuthorList = ({ authors }: AuthorListProps) => {
   const authorsSubset = useMemo(() => authors.slice(0, 5), [authors]);
-  const more = useMemo(() => authors.length - 5, [authors]);
+  const hiddenAuthorsCount = useMemo(() => authors.length - 5, [authors]);
 
   return (
     <AuthorListInner>
@@ -57,7 +80,14 @@ export const AuthorList = ({ authors }: AuthorListProps) => {
           <AuthorName>{author.name}</AuthorName>
         </Author>
       ))}
-      {more > 0 && <MoreAuthors>{`+ ${more} more`}</MoreAuthors>}
+      {hiddenAuthorsCount > 0 && (
+        <HiddenAuthorsWrapper>
+          <IconWrapper>
+            <Icon icon={hiddenAuthorsCount > 1 ? 'users' : 'useralt'} />
+          </IconWrapper>
+          <HiddenAuthors>{`+${hiddenAuthorsCount} more`}</HiddenAuthors>
+        </HiddenAuthorsWrapper>
+      )}
     </AuthorListInner>
   );
 };

--- a/src/components/AuthorList.tsx
+++ b/src/components/AuthorList.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+import { styled } from '@storybook/theming';
+import { typography, color, spacing } from './shared/styles';
+import { Avatar } from './Avatar';
+import { Link } from './Link';
+
+const AuthorName = styled.div`
+  color: ${color.darkest};
+  font-size: ${typography.size.s2}px;
+  line-height: ${typography.size.m1}px;
+  margin-left: ${spacing.padding.small}px;
+`;
+
+const Author = styled(Link)`
+  display: block;
+  margin-bottom: 16px;
+
+  span {
+    display: flex;
+    align-items: center;
+  }
+`;
+
+const AuthorListInner = styled.div`
+  margin-bottom: 40px;
+`;
+
+const MoreAuthors = styled.div`
+  color: ${color.darkest};
+  font-size: ${typography.size.s2}px;
+  line-height: ${typography.size.m1}px;
+  margin-left: ${spacing.padding.small}px;
+`;
+
+export interface AuthorListProps {
+  authors: {
+    id: string;
+    name: string;
+    avatarUrl?: string;
+  }[];
+}
+
+export const AuthorList = ({ authors }: AuthorListProps) => {
+  const authorsSubset = useMemo(() => authors.slice(0, 5), [authors]);
+  const more = useMemo(() => authors.length - 5, [authors]);
+
+  return (
+    <AuthorListInner>
+      {authorsSubset.map((author) => (
+        <Author
+          key={author.id}
+          href={`https://www.npmjs.com/~${author.name}`}
+          target="_blank"
+          rel="noopener nofollow noreferrer"
+        >
+          <Avatar size="medium" username={author.name} src={author.avatarUrl} />
+          <AuthorName>{author.name}</AuthorName>
+        </Author>
+      ))}
+      {more > 0 && <MoreAuthors>{`+ ${more} more`}</MoreAuthors>}
+    </AuthorListInner>
+  );
+};


### PR DESCRIPTION
Fixes https://linear.app/chromaui/issue/CH-710/pull-author-and-authorlist-from-frontpage-into-ds

## Description

Pulled the `AuthorList` component from https://github.com/storybookjs/frontpage into the DS in preparation for future work.

### QA instructions

Confirm the styles (mostly) match [the designs]((https://www.figma.com/file/gYdEmX9zYowUR3K2SOua5J/Component-catalog?node-id=148%3A9975).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.0.4-canary.321.a50c445.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.0.4-canary.321.a50c445.0
  # or 
  yarn add @storybook/design-system@7.0.4-canary.321.a50c445.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
