### PR TITLE
Ensure tertiary Selects are displayed as inline-block instead of blocks

### DIFF
--- a/src/components/Select.stories.tsx
+++ b/src/components/Select.stories.tsx
@@ -166,6 +166,7 @@ export const Stacked = () => (
         { label: 'Dog', value: 'value2' },
       ]}
       onChange={onChange}
+      icon="chromatic"
       stackLevel="middle"
     />
     <Select

--- a/src/components/Select.stories.tsx
+++ b/src/components/Select.stories.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { styled } from '@storybook/theming';
 
-import { Select as UnstyledSelect } from './Select';
+import { Select } from './Select';
 
 const onChange = action('change');
 
 export default {
   title: 'forms/Select',
-  component: UnstyledSelect,
+  component: Select,
 };
 
 export const Template = (args) => <Select {...args} />;
@@ -30,11 +30,11 @@ const DarkForm = styled(Form)`
   background: #eeeeee;
 `;
 
-const Select = styled(UnstyledSelect)`
-  padding-top: 1em;
+const Br = styled.div`
+  margin-bottom: 1em;
 `;
 
-const All = ({ appearance }) => (
+const All = ({ appearance, lineBreak }) => (
   <>
     <Select
       id="Default"
@@ -48,6 +48,7 @@ const All = ({ appearance }) => (
       onChange={onChange}
       appearance={appearance}
     />
+    {lineBreak && <Br />}
     <Select
       id="disabled"
       label="Animal"
@@ -61,6 +62,7 @@ const All = ({ appearance }) => (
       onChange={onChange}
       appearance={appearance}
     />
+    {lineBreak && <Br />}
     <Select
       id="with-icon"
       label="Animal"
@@ -74,6 +76,7 @@ const All = ({ appearance }) => (
       onChange={onChange}
       appearance={appearance}
     />
+    {lineBreak && <Br />}
     <Select
       id="in-progress-with-icon"
       label="Animal"
@@ -88,6 +91,7 @@ const All = ({ appearance }) => (
       appearance={appearance}
       inProgress
     />
+    {lineBreak && <Br />}
     <Select
       id="with-error"
       label="Animal"
@@ -101,6 +105,7 @@ const All = ({ appearance }) => (
       onChange={onChange}
       appearance={appearance}
     />
+    {lineBreak && <Br />}
     <Select
       id="with-icon-and-error"
       label="Animal"
@@ -115,6 +120,7 @@ const All = ({ appearance }) => (
       onChange={onChange}
       appearance={appearance}
     />
+    {lineBreak && <Br />}
     <Select
       id="with-label"
       value="value1"
@@ -132,13 +138,13 @@ const All = ({ appearance }) => (
 
 export const Default = () => (
   <DarkForm>
-    <All appearance="default" />
+    <All appearance="default" lineBreak />
   </DarkForm>
 );
 
 export const Stacked = () => (
   <Form>
-    <UnstyledSelect
+    <Select
       id="default"
       value="value1"
       label="Animal"
@@ -150,7 +156,7 @@ export const Stacked = () => (
       onChange={onChange}
       stackLevel="top"
     />
-    <UnstyledSelect
+    <Select
       id="default1"
       value="value1"
       label="Animal"
@@ -162,7 +168,7 @@ export const Stacked = () => (
       onChange={onChange}
       stackLevel="middle"
     />
-    <UnstyledSelect
+    <Select
       id="default2"
       value="value1"
       label="Animal"
@@ -179,6 +185,6 @@ export const Stacked = () => (
 
 export const Tertiary = () => (
   <Form>
-    <All appearance="tertiary" />
+    <All appearance="tertiary" lineBreak />
   </Form>
 );

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -256,7 +256,7 @@ const SelectWrapper = styled.span<WrapperProps>`
         height: 1em;
         width: 1em;
         margin-top: -0.5em;
-        z-index: 1;
+        z-index: 2;
 
         path {
           fill: ${color.mediumdark};

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -13,7 +13,7 @@ const SelectContainer = styled.div<SelectContainerProps>`
   ${(props) =>
     props.appearance === 'tertiary' &&
     css`
-      display: inline-block;
+      display: inline-flex;
     `}
 `;
 

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -5,6 +5,18 @@ import { jiggle } from './shared/animation';
 import { Icon } from './Icon';
 import { Spinner } from './Spinner';
 
+interface SelectContainerProps {
+  appearance?: 'default' | 'tertiary';
+}
+
+const SelectContainer = styled.div<SelectContainerProps>`
+  ${(props) =>
+    props.appearance === 'tertiary' &&
+    css`
+      display: inline-block;
+    `}
+`;
+
 const Label = styled.label`
   font-weight: ${typography.weight.bold};
   font-size: ${typography.size.s2}px;
@@ -94,9 +106,9 @@ const SelectError = styled.div`
 `;
 
 interface WrapperProps {
-  appearance: 'default' | 'tertiary';
   hasIcon: boolean;
   error: any;
+  appearance?: 'default' | 'tertiary';
   disabled?: boolean;
   inProgress?: boolean;
   stackLevel?: 'top' | 'middle' | 'bottom';
@@ -327,7 +339,7 @@ export const Select: FunctionComponent<Props & ComponentProps<typeof Selector>> 
   }
 
   return (
-    <div className={className}>
+    <SelectContainer className={className} appearance={appearance}>
       <LabelWrapper hideLabel={hideLabel}>
         <Label htmlFor={id}>{label}</Label>
       </LabelWrapper>
@@ -359,6 +371,6 @@ export const Select: FunctionComponent<Props & ComponentProps<typeof Selector>> 
         {error && <SelectError id={errorId}>{error}</SelectError>}
         {inProgress && <SelectSpinner id={spinnerId} aria-label="Loading" inForm />}
       </SelectWrapper>
-    </div>
+    </SelectContainer>
   );
 };


### PR DESCRIPTION
Minor tweak so that Select's with `tertiary` styling occupies only the space it needs and does expand to the full width of the container. 

See that the red boxes (the container) is perfectly sized for the Select.
![image](https://user-images.githubusercontent.com/263385/150656662-90384181-b463-465e-b943-2cbf2077ed8e.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.2.6-canary.335.7190329.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.2.6-canary.335.7190329.0
  # or 
  yarn add @storybook/design-system@7.2.6-canary.335.7190329.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
