### PR TITLE
Refine styling to be more compact in mobile view

### DIFF
--- a/src/components/OutlineCTA.stories.tsx
+++ b/src/components/OutlineCTA.stories.tsx
@@ -38,6 +38,9 @@ Default.args = {
   badge: <Badge status="positive">New</Badge>,
   children: 'These docs are for version 6.0. Newer docs are available for version 6.4.',
 };
+Default.parameters = {
+  chromatic: { viewports: [320, 1200] },
+};
 
 export const NoBadge = Story.bind({});
 NoBadge.args = {

--- a/src/components/OutlineCTA.tsx
+++ b/src/components/OutlineCTA.tsx
@@ -6,28 +6,19 @@ import { breakpoint, color, spacing, typography } from './shared/styles';
 const OutlineCTAWrapper = styled.div`
   border-radius: ${spacing.borderRadius.small}px;
   box-shadow: ${color.border} 0 0 0 1px inset;
-  padding: ${spacing.padding.small}px ${spacing.padding.medium}px;
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: center;
-  text-align: center;
+  padding: ${spacing.padding.small}px ${spacing.padding.small}px;
+
+  font-size: ${typography.size.s2}px;
+  line-height: 20px;
 
   @media (min-width: ${breakpoint}px) {
     flex-wrap: nowrap;
     justify-content: flex-start;
-    text-align: left;
+    padding: ${spacing.padding.small}px ${spacing.padding.medium}px;
   }
 `;
 
-const MessageText = styled.p`
-  font-size: ${typography.size.s2}px;
-  margin: 0;
-`;
-
 const ActionWrapper = styled.span`
-  font-size: ${typography.size.s2}px;
   font-weight: ${typography.weight.bold};
   white-space: nowrap;
 `;
@@ -42,9 +33,7 @@ interface Props {
 
 export const OutlineCTA = ({ action, badge, children, ...rest }: Props) => (
   <OutlineCTAWrapper {...rest}>
-    {badge}
-    <MessageText>{children}</MessageText>
-    <ActionWrapper>{action}</ActionWrapper>
+    {badge} {children} <ActionWrapper>{action}</ActionWrapper>
   </OutlineCTAWrapper>
 );
 

--- a/src/components/OutlineCTA.tsx
+++ b/src/components/OutlineCTA.tsx
@@ -18,6 +18,11 @@ const OutlineCTAWrapper = styled.div`
   }
 `;
 
+const MessageText = styled.span`
+  margin-left: 2px;
+  margin-right: 2px;
+`;
+
 const ActionWrapper = styled.span`
   font-weight: ${typography.weight.bold};
   white-space: nowrap;
@@ -33,7 +38,7 @@ interface Props {
 
 export const OutlineCTA = ({ action, badge, children, ...rest }: Props) => (
   <OutlineCTAWrapper {...rest}>
-    {badge} {children} <ActionWrapper>{action}</ActionWrapper>
+    {badge} <MessageText>{children}</MessageText> <ActionWrapper>{action}</ActionWrapper>
   </OutlineCTAWrapper>
 );
 


### PR DESCRIPTION
New mobile view that is more compact. I added this so that I could propagate these changes to the frontpage.
<img width="376" alt="image" src="https://user-images.githubusercontent.com/263385/157901926-76479124-24d4-4616-b5ed-0167ed5792b1.png">

**Why?**
The current mobile view takes up too much space and doesn't wrap.
<img width="543" alt="image" src="https://user-images.githubusercontent.com/263385/157902296-c1db56e1-feef-4690-9e79-c13e63c4d7b7.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.1-canary.343.7be6f0c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.3.1-canary.343.7be6f0c.0
  # or 
  yarn add @storybook/design-system@7.3.1-canary.343.7be6f0c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
