### PR TITLE
FormErrorState: Allow outside control of error messages

### DIFF
--- a/src/components/FormErrorState.stories.tsx
+++ b/src/components/FormErrorState.stories.tsx
@@ -104,3 +104,12 @@ PureMultipleErrors.args = {
   blurredFieldIds: new Set(['input-1', 'input-2']),
   children: Children,
 };
+
+export const PureMultipleErrorsSuppressed = (args: PureFormErrorStateProps) => (
+  <PureFormErrorState {...args} />
+);
+PureMultipleErrorsSuppressed.decorators = decorators;
+PureMultipleErrorsSuppressed.args = {
+  ...PureMultipleErrors.args,
+  suppressErrorMessages: true,
+};

--- a/src/components/FormErrorState.tsx
+++ b/src/components/FormErrorState.tsx
@@ -27,6 +27,7 @@ export interface FormErrorStateChildrenArgs {
 export interface FormErrorStateProps {
   onSubmit: Function;
   children: (args: FormErrorStateChildrenArgs) => JSX.Element;
+  suppressErrorMessages: boolean;
 }
 
 export interface PureFormErrorStateProps extends FormErrorStateProps {
@@ -40,6 +41,7 @@ export interface PureFormErrorStateProps extends FormErrorStateProps {
 
 export const PureFormErrorState = ({
   children,
+  suppressErrorMessages,
   onSubmit,
   onMouseEnter,
   onMouseLeave,
@@ -54,7 +56,7 @@ export const PureFormErrorState = ({
     onFocus: () => onFocus(id),
     onBlur: () => onBlur(id),
     error: (value: string) => getError({ id, value, validate }),
-    suppressErrorMessage: !primaryFieldId || primaryFieldId !== id,
+    suppressErrorMessage: suppressErrorMessages || !primaryFieldId || primaryFieldId !== id,
   });
 
   return children({ getFormErrorFieldProps, onSubmit });


### PR DESCRIPTION
Small detail on the collapsible forms that would be nice to customize. We have this form on Chromatic that is in a collapsible section & when it is collapsing with error tooltips open, they linger visually when the section collapses past them. The tooltips are mounted in a portal so they can't be controlled easily via overflow styling on a parent element, hence this solution here.

**Broken**
![broken-hd](https://user-images.githubusercontent.com/3035355/162068546-bccd28f2-a49a-4c8d-a977-dea27e8e98c5.gif)

**Fixed**
![fixed-hd](https://user-images.githubusercontent.com/3035355/162068600-6034ae1b-d5cc-483c-bfed-55cd9fa394e9.gif)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.2-canary.349.3a74afc.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.3.2-canary.349.3a74afc.0
  # or 
  yarn add @storybook/design-system@7.3.2-canary.349.3a74afc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
