### PR TITLE
Checkbox: checkboxColor is not actually required

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -119,14 +119,9 @@ interface Props {
   error?: ReactNode;
 }
 
-export const Checkbox: FunctionComponent<Props & ComponentProps<typeof Input>> = ({
-  appearance = 'primary',
-  id,
-  label,
-  error,
-  hideLabel,
-  ...props
-}) => {
+export const Checkbox: FunctionComponent<
+  Props & Omit<ComponentProps<typeof Input>, 'checkboxColor'>
+> = ({ appearance = 'primary', id, label, error, hideLabel, ...props }) => {
   const errorId = `${id}-error`;
   const checkboxColor = color[appearance];
   return (


### PR DESCRIPTION
Our Checkbox component had some types that were actually conflicting with the current story args, but I noticed when importing it into another app that `checkboxColor` is a required prop when it shouldn't be.

The `checkboxColor` is inferred in the main component & passed down to an emotion component, where it is required. The main component inferred styles from the emotion component, hence the requirement, but I am choosing to omit the `checkboxColor` in the main component's styles now to avoid this issue.