### PR TITLE
Make Icon size in Buttons smaller

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -43,6 +43,35 @@ export const Sizes = () => (
   </>
 );
 
+export const ContainsSVG = () => (
+  <>
+    <Button appearance="secondary">
+      <Icon icon="lock" />
+      Default
+    </Button>
+    <Button appearance="secondary" size="small">
+      <Icon icon="lock" />
+      Small
+    </Button>
+    <Button appearance="secondary">
+      <Icon icon="check" />
+      Default
+    </Button>
+    <Button appearance="secondary" size="small">
+      <Icon icon="check" />
+      Small
+    </Button>
+    <Button appearance="secondary">
+      <Icon icon="grid" />
+      Default
+    </Button>
+    <Button appearance="secondary" size="small">
+      <Icon icon="grid" />
+      Small
+    </Button>
+  </>
+);
+
 export const Loading = () => (
   <>
     <Button appearance="primary" isLoading>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -88,12 +88,12 @@ export const StyledButton = styled.button<StylingProps & { children: ReactElemen
   }
 
   svg {
-    height: ${(props) => (props.size === SIZES.SMALL ? '14' : '16')}px;
-    width: ${(props) => (props.size === SIZES.SMALL ? '14' : '16')}px;
+    height: ${(props) => (props.size === SIZES.SMALL ? '12' : '14')}px;
+    width: ${(props) => (props.size === SIZES.SMALL ? '12' : '14')}px;
     vertical-align: top;
     margin-right: ${(props) => (props.size === SIZES.SMALL ? '4' : '6')}px;
-    margin-top: ${(props) => (props.size === SIZES.SMALL ? '-1' : '-2')}px;
-    margin-bottom: ${(props) => (props.size === SIZES.SMALL ? '-1' : '-2')}px;
+    margin-top: ${(props) => (props.size === SIZES.SMALL ? '0' : '-1')}px;
+    margin-bottom: ${(props) => (props.size === SIZES.SMALL ? '0' : '-2')}px;
 
     /* Necessary for js mouse events to not glitch out when hovering on svgs */
     pointer-events: none;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -93,7 +93,7 @@ export const StyledButton = styled.button<StylingProps & { children: ReactElemen
     vertical-align: top;
     margin-right: ${(props) => (props.size === SIZES.SMALL ? '4' : '6')}px;
     margin-top: ${(props) => (props.size === SIZES.SMALL ? '0' : '-1')}px;
-    margin-bottom: ${(props) => (props.size === SIZES.SMALL ? '0' : '-2')}px;
+    margin-bottom: ${(props) => (props.size === SIZES.SMALL ? '0' : '-1')}px;
 
     /* Necessary for js mouse events to not glitch out when hovering on svgs */
     pointer-events: none;
@@ -147,6 +147,8 @@ export const StyledButton = styled.button<StylingProps & { children: ReactElemen
       svg {
         display: block;
         margin: 0;
+        height: ${props.size === SIZES.SMALL ? '14' : '16'}px;
+        width: ${props.size === SIZES.SMALL ? '14' : '16'}px;
       }
       padding: ${props.size === SIZES.SMALL ? '7' : '12'}px;
     `}


### PR DESCRIPTION
1. Icons in large Buttons went from 16px to 14px
2. Icons in small Buttons went from 14px to 12px

Both remain perfectly vertically centered.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.7.1-canary.368.e086f4a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.7.1-canary.368.e086f4a.0
  # or 
  yarn add @storybook/design-system@7.7.1-canary.368.e086f4a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
