### PR TITLE
Link, Button: Rename prop containsIcon to containsIconOnly 

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -109,12 +109,12 @@ export const Disabled = () => (
   </>
 );
 
-export const ContainsIcon = () => (
+export const ContainsIconOnly = () => (
   <>
-    <Button appearance="outline" containsIcon>
+    <Button appearance="outline" containsIconOnly>
       <Icon icon="link" aria-label="Link" />
     </Button>
-    <Button appearance="outline" size="small" containsIcon>
+    <Button appearance="outline" size="small" containsIconOnly>
       <Icon icon="link" aria-label="Link" />
     </Button>
   </>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -142,7 +142,7 @@ export const StyledButton = styled.button<StylingProps & { children: ReactElemen
     `}
 
   ${(props) =>
-    props.containsIcon &&
+    props.containsIconOnly &&
     `
       svg {
         display: block;
@@ -337,7 +337,7 @@ const ButtonLink = styled.a``;
 interface StylingProps {
   isLoading?: boolean;
   isUnclickable?: boolean;
-  containsIcon?: boolean;
+  containsIconOnly?: boolean;
   disabled?: boolean;
   size?: typeof SIZES[keyof typeof SIZES];
   appearance?: typeof APPEARANCES[keyof typeof APPEARANCES];

--- a/src/components/Link.stories.tsx
+++ b/src/components/Link.stories.tsx
@@ -47,13 +47,13 @@ export const All = () => (
 );
 
 export const WithArrow = () => (
-  <Link containsIcon withArrow href="https://learnstorybook.com">
+  <Link containsIconOnly withArrow href="https://learnstorybook.com">
     withArrow shows an arrow behind the link
   </Link>
 );
 
-export const ContainsIcon = () => (
-  <Link containsIcon href="https://learnstorybook.com" aria-label="Toggle side bar">
+export const ContainsIconOnly = () => (
+  <Link containsIconOnly href="https://learnstorybook.com" aria-label="Toggle side bar">
     <Icon icon="sidebar" aria-hidden />
   </Link>
 );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -21,7 +21,7 @@ const LinkInner = styled.span<{ withArrow: boolean }>`
 `;
 
 interface StyledLinkProps {
-  containsIcon?: boolean;
+  containsIconOnly?: boolean;
   secondary?: boolean;
   tertiary?: boolean;
   nochrome?: boolean;
@@ -56,7 +56,7 @@ const StyledLink = styled.a<StyledLinkProps>`
   }
 
   ${(props) =>
-    props.containsIcon &&
+    props.containsIconOnly &&
     css`
       svg {
         height: 1em;
@@ -148,7 +148,7 @@ export type LinkProps = React.ComponentProps<typeof StyledLink> & {
 const LinkComponentPicker = forwardRef<HTMLAnchorElement | HTMLButtonElement, LinkProps>(
   (
     {
-      containsIcon,
+      containsIconOnly,
       inverse,
       isButton,
       LinkWrapper,
@@ -200,7 +200,7 @@ export const Link = forwardRef<HTMLAnchorElement | HTMLButtonElement, LinkProps>
 Link.defaultProps = {
   withArrow: false,
   isButton: false,
-  containsIcon: false,
+  containsIconOnly: false,
   secondary: false,
   tertiary: false,
   nochrome: false,

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -88,7 +88,7 @@ export const Modal: FC<Props> = ({ isBlank = false, isOpen, onClose, children })
 
       {!isBlank && (
         <Action>
-          <Button containsIcon appearance="outline" onClick={onClose}>
+          <Button containsIconOnly appearance="outline" onClick={onClose}>
             <Icon icon="cross" />
           </Button>
         </Action>


### PR DESCRIPTION
**What?**
Link and Button have a prop called `containsIcon`. This prop is intended for situations where these components **only** contain an icon (no children). But the naming is misleading because you'd think you could apply it when there are children present (but that ends up messing with the alignment).

This PR seeks to improve the naming so reusing the Link and Button components is clearer.

@kylesuss can you review and guide me on whether this is a `patch`, `minor`, or `major` release?