### PR TITLE
Add inverse status to cardinal

### DIFF
--- a/src/components/Cardinal.stories.tsx
+++ b/src/components/Cardinal.stories.tsx
@@ -19,6 +19,9 @@ export const AllCardinals = () => (
     <Cardinal size="small" count={4} text="Denied" noPlural status="negative" />
     <Cardinal size="small" count={3} text="Unreviewed" noPlural status="warning" />
     <Cardinal size="small" count={0} text="Unreviewed" noPlural status="neutral" />
+    <div style={{ background: '#171C23', display: 'inline-block' }}>
+      <Cardinal size="small" count={0} text="Unreviewed" noPlural status="inverse" />
+    </div>
     <br />
     <Cardinal
       selectable

--- a/src/components/Cardinal.tsx
+++ b/src/components/Cardinal.tsx
@@ -6,7 +6,7 @@ import { Link } from './Link';
 import { background, color, typography, spacing } from './shared/styles';
 import { inlineGlow } from './shared/animation';
 
-type Status = 'default' | 'positive' | 'negative' | 'warning' | 'neutral' | 'link';
+type Status = 'default' | 'positive' | 'negative' | 'warning' | 'neutral' | 'link' | 'inverse';
 type Size = 'small' | 'large';
 type Alignment = 'left' | 'center' | 'right';
 
@@ -50,6 +50,11 @@ const Count = styled.div<CountProps>`
         color: ${darken(0.1, color.secondary)};
       }
     `};
+  ${(props) =>
+    props.status === 'inverse' &&
+    css`
+      color: rgba(255, 255, 255, 0.7);
+    `};
 
   span {
     display: inline-block;
@@ -68,6 +73,7 @@ interface CardinalInnerProps {
   active: boolean;
   size: Size;
   alignment: Alignment;
+  inverse?: boolean;
 }
 
 const CardinalInner = styled.div<CardinalInnerProps>`
@@ -127,7 +133,7 @@ const CardinalInner = styled.div<CardinalInnerProps>`
   }
 
   ${Text} {
-    color: ${color.dark};
+    color: ${(props) => (props.inverse ? 'rgba(255, 255, 255, 0.5)' : color.dark)};
     font-size: ${(props) => (props.size === 'small' ? typography.size.s1 : typography.size.s2)}px;
     line-height: ${(props) => (props.size === 'small' ? typography.size.s2 : typography.size.m1)}px;
     clear: both;
@@ -188,6 +194,7 @@ export function Cardinal({
       active={active}
       size={size}
       alignment={alignment}
+      inverse={status === 'inverse'}
       {...events}
       {...props}
     >


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.7.15-canary.383.7ba4926.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.7.15-canary.383.7ba4926.0
  # or 
  yarn add @storybook/design-system@7.7.15-canary.383.7ba4926.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
