### PR TITLE
feat(WithTooltip): support Storybook 7 root element

### DIFF
--- a/src/components/tooltip/WithTooltip.tsx
+++ b/src/components/tooltip/WithTooltip.tsx
@@ -74,6 +74,7 @@ const AsComponent = React.forwardRef<unknown, Pick<Props, 'tagName'> & Record<st
     return <Component {...asProps} />;
   }
 );
+AsComponent.displayName = 'AsComponent';
 
 const WithTooltip: FC<Props & ComponentProps<typeof AsComponent>> = ({
   children,
@@ -110,7 +111,11 @@ const WithTooltip: FC<Props & ComponentProps<typeof AsComponent>> = ({
 
   /* eslint-env browser */
   const defaultPortalContainer =
-    typeof window !== 'undefined' ? document.getElementById('root') || document.body : undefined;
+    typeof window !== 'undefined'
+      ? document.getElementById('storybook-root') ||
+        document.getElementById('root') ||
+        document.body
+      : undefined;
 
   return (
     <TooltipTrigger
@@ -170,10 +175,12 @@ interface Props {
   placement?: ComponentProps<typeof TooltipTrigger>['placement'];
   modifiers?: any;
   hasChrome?: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   tooltip?: ReactNode | Function;
   children: ReactNode;
   startOpen?: boolean;
   delayHide?: number;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   onVisibilityChange?: Function;
   portalContainer?: ComponentProps<typeof TooltipTrigger>['portalContainer'];
   tooltipZIndex?: number;


### PR DESCRIPTION
Storybook 7.0 changed its root element to `'storybook-root'` so the Tooltip component should support that too
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.9.1-canary.394.421dfce.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.9.1-canary.394.421dfce.0
  # or 
  yarn add @storybook/design-system@7.9.1-canary.394.421dfce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
