### PR TITLE
Update colors in the design system to match SB 7.0

### DIFF
--- a/src/components/CodeSnippets.tsx
+++ b/src/components/CodeSnippets.tsx
@@ -13,7 +13,7 @@ const Background = styled.div`
   background-color: #f7f9fc;
   border: 1px solid ${color.border};
   border-radius: ${spacing.borderRadius.small}px;
-  box-shadow: 0 2px 5px 0 ${color.border};
+  box-shadow: 0 2px 5px 0 ${color.tr10};
 `;
 
 const StyledHighlight = styled(Highlight)`

--- a/src/components/shared/animation.ts
+++ b/src/components/shared/animation.ts
@@ -54,7 +54,7 @@ export const shake = keyframes`
 
 export const inlineGlow = css`
   animation: ${glow} 1.5s ease-in-out infinite;
-  background: ${color.mediumlight};
+  background: ${color.tr5};
   color: transparent;
   cursor: progress;
 `;

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -15,7 +15,7 @@ export const color = {
   // Palette
   primary: '#FF4785', // Coral
   secondary: '#029CFD', // Ocean
-  tertiary: '#FAFBFC', // Light grey
+  tertiary: '#E3E6E8', // Light grey
 
   orange: '#FC521F',
   gold: '#FFAE00',
@@ -27,7 +27,7 @@ export const color = {
 
   // Calm
   blueLighter: '#E3F3FF', // rgba($color.blue, 12%)
-  blueLight: '#F3FAFF', // rgba($color.blue, 6%)
+  blueLight: '#F5FBFF', // rgba($color.blue, 6%)
 
   // Monochrome
   lightest: '#FFFFFF',

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -26,8 +26,8 @@ export const color = {
   red: '#ff4400',
 
   // Calm
-  blueLight: '#E3F3FF', // rgba($color.blue, 12%)
-  blueLighter: '#F5FBFF',
+  bluelight: '#E3F3FF', // rgba($color.blue, 12%)
+  bluelighter: '#F5FBFF',
 
   // Monochrome
   lightest: '#FFFFFF',

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -26,8 +26,8 @@ export const color = {
   red: '#ff4400',
 
   // Calm
-  blueLighter: '#E3F3FF', // rgba($color.blue, 12%)
-  blueLight: '#F5FBFF',
+  blueLight: '#E3F3FF', // rgba($color.blue, 12%)
+  blueLighter: '#F5FBFF',
 
   // Monochrome
   lightest: '#FFFFFF',

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -14,8 +14,8 @@ export const background = {
 export const color = {
   // Palette
   primary: '#FF4785', // Coral
-  secondary: '#1EA7FD', // Ocean
-  tertiary: '#DDDDDD', // Light grey
+  secondary: '#029CFD', // Ocean
+  tertiary: '#FAFBFC', // Light grey
 
   orange: '#FC521F',
   gold: '#FFAE00',
@@ -31,18 +31,18 @@ export const color = {
 
   // Monochrome
   lightest: '#FFFFFF',
-  lighter: '#F8F8F8',
-  light: '#F3F3F3',
-  mediumlight: '#EEEEEE',
-  medium: '#DDDDDD',
-  mediumdark: '#999999',
-  dark: '#666666',
-  darker: '#444444',
-  darkest: '#333333',
+  lighter: '#F7FAFC',
+  light: '#EEF3F6',
+  mediumlight: '#ECF4F9',
+  medium: '#D9E8F2',
+  mediumdark: '#73828C',
+  dark: '#5C6870',
+  darker: '#454E54',
+  darkest: '#2E3438',
   tr10: 'rgba(0, 0, 0, 0.1)',
   tr5: 'rgba(0, 0, 0, 0.05)',
 
-  border: 'rgba(0,0,0,.1)',
+  border: 'hsla(203, 50%, 30%, 0.2)',
 
   // Status
   positive: '#448028', // Evergreen

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -27,7 +27,7 @@ export const color = {
 
   // Calm
   blueLighter: '#E3F3FF', // rgba($color.blue, 12%)
-  blueLight: '#F5FBFF', // rgba($color.blue, 6%)
+  blueLight: '#F5FBFF',
 
   // Monochrome
   lightest: '#FFFFFF',

--- a/src/components/shared/styles.ts
+++ b/src/components/shared/styles.ts
@@ -42,7 +42,7 @@ export const color = {
   tr10: 'rgba(0, 0, 0, 0.1)',
   tr5: 'rgba(0, 0, 0, 0.05)',
 
-  border: 'hsla(203, 50%, 30%, 0.2)',
+  border: 'hsla(203, 50%, 30%, 0.15)',
 
   // Status
   positive: '#448028', // Evergreen

--- a/src/components/tag/TagItem.tsx
+++ b/src/components/tag/TagItem.tsx
@@ -24,7 +24,7 @@ export const TagItem = styled(
     shouldForwardProp: (prop) => prop !== 'theme' && prop !== 'as',
   }
 )<TagItemProps>`
-  background: ${color.blueLight};
+  background: ${color.blueLighter};
   border-color: transparent;
   border-radius: ${spacing.borderRadius.small}px;
   border-style: solid;

--- a/src/components/tag/TagItem.tsx
+++ b/src/components/tag/TagItem.tsx
@@ -24,7 +24,7 @@ export const TagItem = styled(
     shouldForwardProp: (prop) => prop !== 'theme' && prop !== 'as',
   }
 )<TagItemProps>`
-  background: ${color.blueLighter};
+  background: ${color.bluelighter};
   border-color: transparent;
   border-radius: ${spacing.borderRadius.small}px;
   border-style: solid;

--- a/src/components/tag/TagItem.tsx
+++ b/src/components/tag/TagItem.tsx
@@ -24,7 +24,7 @@ export const TagItem = styled(
     shouldForwardProp: (prop) => prop !== 'theme' && prop !== 'as',
   }
 )<TagItemProps>`
-  background: ${color.lighter};
+  background: ${color.blueLight};
   border-color: transparent;
   border-radius: ${spacing.borderRadius.small}px;
   border-style: solid;

--- a/src/components/tag/TagItem.tsx
+++ b/src/components/tag/TagItem.tsx
@@ -24,7 +24,7 @@ export const TagItem = styled(
     shouldForwardProp: (prop) => prop !== 'theme' && prop !== 'as',
   }
 )<TagItemProps>`
-  background: ${color.blueLight};
+  background: ${color.lighter};
   border-color: transparent;
   border-radius: ${spacing.borderRadius.small}px;
   border-style: solid;


### PR DESCRIPTION
I matched the colors best I could. Most are 1:1. The biggest exception is the tertiary color. For the Design System, it should be a darker grey - for Storybook a lighter grey. That has more to do with the major stylistic differences in the two buttons. We could potentially reconcile those, but that would be a larger change than just colors.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.11.1-canary.401.c1ebd15.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.11.1-canary.401.c1ebd15.0
  # or 
  yarn add @storybook/design-system@7.11.1-canary.401.c1ebd15.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
