### PR TITLE
update cardinal types

### DIFF
--- a/src/components/Cardinal.tsx
+++ b/src/components/Cardinal.tsx
@@ -1,6 +1,6 @@
 import pluralize from 'pluralize';
 import { darken } from 'polished';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { styled, css } from '@storybook/theming';
 import { Link } from './Link';
 import { background, color, typography, spacing } from './shared/styles';
@@ -175,7 +175,7 @@ export interface CardinalProps {
   alignment?: Alignment;
 }
 
-export function Cardinal({
+export const Cardinal: FunctionComponent<CardinalProps> = ({
   isLoading,
   selectable,
   onHover,
@@ -191,7 +191,7 @@ export function Cardinal({
   TextWrapper,
   alignment,
   ...props
-}: CardinalProps) {
+}) => {
   let countValue = count;
   if (countLink) {
     countValue = (
@@ -230,9 +230,9 @@ export function Cardinal({
       </Text>
     </CardinalInner>
   );
-}
+};
 
-const DefaultWrapper: React.FunctionComponent = ({ children }) => <span>{children}</span>;
+const DefaultWrapper: FunctionComponent = ({ children }) => <span>{children}</span>;
 
 Cardinal.defaultProps = {
   isLoading: false,

--- a/src/components/Cardinal.tsx
+++ b/src/components/Cardinal.tsx
@@ -159,19 +159,19 @@ const CardinalInner = styled.div<CardinalInnerProps>`
 `;
 
 export interface CardinalProps {
-  isLoading: boolean;
-  selectable: boolean;
-  active: boolean;
-  size: Size;
-  onHover: (e: boolean) => void;
-  onClick: React.FormEventHandler<HTMLInputElement>;
+  isLoading?: boolean;
+  selectable?: boolean;
+  active?: boolean;
+  size?: Size;
+  onHover?: (e: boolean) => void;
+  onClick?: React.FormEventHandler<HTMLInputElement>;
   count: React.ReactNode;
-  countLink: string;
+  countLink?: string;
   text: string;
-  status: Status;
-  noPlural: boolean;
-  CountWrapper: React.ElementType;
-  TextWrapper: React.ElementType;
+  status?: Status;
+  noPlural?: boolean;
+  CountWrapper?: React.ElementType;
+  TextWrapper?: React.ElementType;
   alignment?: Alignment;
 }
 


### PR DESCRIPTION
While working in Chromatic, I started running into some issues using the Cardinal component in Typescript with emotion. The main piece of this PR is to type Cardinal as a `FunctionComponent`. Based on usage across repositories, I also went ahead and configured which props should be optional.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.12.3-canary.405.cde7bcd.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.12.3-canary.405.cde7bcd.0
  # or 
  yarn add @storybook/design-system@7.12.3-canary.405.cde7bcd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
