### PR TITLE
Update Tooltips to use Word Break on long words

### DIFF
--- a/src/components/tooltip/TooltipMessage.stories.tsx
+++ b/src/components/tooltip/TooltipMessage.stories.tsx
@@ -70,6 +70,6 @@ withCustomClass.storyName = 'with custom className';
 
 export const BreakWord = {
   render: () => (
-    <TooltipMessage desc="App for repository github:sfdjglbnfslgbnbdsoiufbgdfjbdfsljbdflibsfbjdslf= already exists" />
+    <TooltipMessage desc="App for repository github:sfdjglbnfslgbnbdsoiufbgdfjbdfsljbdflibsdfsfdhdfhfgdhfdgfbjdslf= already exists" />
   ),
 };

--- a/src/components/tooltip/TooltipMessage.stories.tsx
+++ b/src/components/tooltip/TooltipMessage.stories.tsx
@@ -67,3 +67,9 @@ export const withCustomClass = () => {
 };
 
 withCustomClass.storyName = 'with custom className';
+
+export const BreakWord = {
+  render: () => (
+    <TooltipMessage desc="App for repository github:sfdjglbnfslgbnbdsoiufbgdfjbdfsljbdflibsfbjdslf= already exists" />
+  ),
+};

--- a/src/components/tooltip/TooltipMessage.tsx
+++ b/src/components/tooltip/TooltipMessage.tsx
@@ -29,6 +29,7 @@ const MessageWrapper = styled.div`
   padding: 15px;
   width: 280px;
   box-sizing: border-box;
+  word-break: break-word;
 `;
 
 export function TooltipMessage({


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.15.12-canary.420.ac61780.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/design-system@7.15.12-canary.420.ac61780.0
  # or 
  yarn add @storybook/design-system@7.15.12-canary.420.ac61780.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
