### PR TITLE
Override WithTooltips default role of 'button'

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -383,6 +383,7 @@ export const PureInput = forwardRef<
             tooltip={
               errorMessage && !suppressErrorMessage && <ErrorTooltipMessage desc={errorMessage} />
             }
+            role="none"
           >
             {inputEl}
           </ErrorTooltip>


### PR DESCRIPTION
The `Input` component contains an `ErrorTooltip` wrapper (an instance of `WithTooltip`). That wrapper, by default, has an aria role of 'button'. It's very strange for an input field to have a button role and it is causing problems with iOS VoiceControl, where selecting that field does not show the on-screen keyboard.

With this change, the role will be overriden to 'none', allowing the keyboard to show.